### PR TITLE
Enable cross-origin requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ npm install
 npm run dev
 ```
 
-Afterwards open `http://localhost:5173` in your browser.  The app will call the backend at `http://localhost:8000` by default.
+Afterwards open `http://localhost:5173` in your browser.  If the backend runs on a different port, set the environment variable `VITE_API_BASE` when starting the
+frontend, e.g. `VITE_API_BASE=http://localhost:8000 npm run dev`.
 
 ---
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,19 @@
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
 import logging
 
 from .api import ingredients, recipes, inventory
 
 app = FastAPI(title="Bar Management")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- allow requests from the frontend dev server by adding CORS middleware
- update README with instructions for setting `VITE_API_BASE`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870134a41d4833091206f06b936a170