### PR TITLE
Add cocktail search and recipe import

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -2,9 +2,15 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from ..db import crud, schemas, session
-from ..services.cocktaildb import fetch_recipe_name
+from ..services.cocktaildb import fetch_recipe_name, search_recipes
 
 router = APIRouter()
+
+
+@router.get("/search", response_model=list[schemas.RecipeBase])
+async def search_recipes_endpoint(q: str):
+    names = await search_recipes(q)
+    return [{"name": n} for n in names]
 
 @router.get("/", response_model=list[schemas.Recipe])
 def list_recipes(skip: int = 0, limit: int = 100, db: Session = Depends(session.get_db)):

--- a/backend/app/services/cocktaildb.py
+++ b/backend/app/services/cocktaildb.py
@@ -13,3 +13,15 @@ async def fetch_recipe_name(name: str) -> str | None:
         if not drinks:
             return None
         return drinks[0].get("strDrink")
+
+
+async def search_recipes(name: str) -> list[str]:
+    """Return a list of recipe names matching the search term."""
+    url = f"{API_BASE}/search.php"
+    params = {"s": name}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        drinks = data.get("drinks") or []
+        return [d.get("strDrink") for d in drinks if d.get("strDrink")]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -73,6 +73,18 @@ async def test_create_recipe(monkeypatch, async_client):
 
 
 @pytest.mark.asyncio
+async def test_recipe_search(monkeypatch, async_client):
+    async def fake_search(name: str):
+        return ["Margarita", "Blue Margarita"]
+
+    monkeypatch.setattr("backend.app.services.cocktaildb.search_recipes", fake_search)
+    monkeypatch.setattr("backend.app.api.recipes.search_recipes", fake_search)
+    resp = await async_client.get("/recipes/search", params={"q": "margarita"})
+    assert resp.status_code == 200
+    assert resp.json() == [{"name": "Margarita"}, {"name": "Blue Margarita"}]
+
+
+@pytest.mark.asyncio
 async def test_inventory_patch(async_client):
     # seed ingredient and item
     resp = await async_client.post("/ingredients/", json={"name": "Vodka"})

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,3 +49,22 @@ export async function lookupBarcode(ean: string) {
   if (!res.ok) return null;
   return res.json();
 }
+
+export async function listRecipes() {
+  const res = await fetch(`${API_BASE}/recipes/`);
+  return res.json();
+}
+
+export async function searchRecipes(q: string) {
+  const res = await fetch(`${API_BASE}/recipes/search?q=${encodeURIComponent(q)}`);
+  return res.json();
+}
+
+export async function createRecipe(data: { name: string }) {
+  const res = await fetch(`${API_BASE}/recipes/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  return res.json();
+}

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -1,8 +1,77 @@
+import { useEffect, useState } from 'react';
+import { listRecipes, searchRecipes, createRecipe } from '../api';
+
+interface Recipe {
+  name: string;
+  id?: number;
+}
+
 export default function Recipes() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Recipe[]>([]);
+  const [saved, setSaved] = useState<Recipe[]>([]);
+
+  const refresh = () => {
+    listRecipes().then(setSaved);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const runSearch = async () => {
+    if (!query) return;
+    const res = await searchRecipes(query);
+    setResults(res);
+  };
+
+  const save = async (name: string) => {
+    await createRecipe({ name });
+    refresh();
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Recipes</h1>
-      <p className="text-gray-700">Browse and add your favourite cocktails.</p>
+      <div className="space-x-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search cocktails"
+          className="border p-1"
+        />
+        <button onClick={runSearch} className="rounded bg-blue-500 px-2 py-1 text-white">
+          Search
+        </button>
+      </div>
+      {results.length > 0 && (
+        <div>
+          <h2 className="font-semibold">Results</h2>
+          <ul className="list-disc pl-5">
+            {results.map((r) => (
+              <li key={r.name} className="my-1 flex items-center space-x-2">
+                <span>{r.name}</span>
+                <button
+                  onClick={() => save(r.name)}
+                  className="rounded bg-green-500 px-1 text-white"
+                >
+                  Add
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {saved.length > 0 && (
+        <div>
+          <h2 className="font-semibold">Saved Recipes</h2>
+          <ul className="list-disc pl-5">
+            {saved.map((s) => (
+              <li key={s.id || s.name}>{s.name}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -17,6 +17,14 @@ paths:
             type: integer
     post:
       summary: Create ingredient
+  /recipes/search:
+    get:
+      summary: Search recipes from CocktailDB
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
   /recipes:
     get:
       summary: List recipes


### PR DESCRIPTION
## Summary
- support searching recipes from the CocktailDB API
- expose `/recipes/search` endpoint in backend and OpenAPI
- extend frontend API helpers
- implement recipe search page with ability to save a found recipe
- test new search endpoint

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-asyncio httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702ae8a8248330ba51524ceb2f7d52