### PR TITLE
Extend recipes with extra info

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from ..db import crud, schemas, session
-from ..services.cocktaildb import fetch_recipe_name, search_recipes
+from ..services.cocktaildb import fetch_recipe_details, search_recipes
 
 router = APIRouter()
 
@@ -19,7 +19,7 @@ def list_recipes(skip: int = 0, limit: int = 100, db: Session = Depends(session.
 
 @router.post("/", response_model=schemas.Recipe, status_code=201)
 async def create_recipe(recipe: schemas.RecipeCreate, db: Session = Depends(session.get_db)):
-    fetched = await fetch_recipe_name(recipe.name)
-    if fetched:
-        recipe.name = fetched
+    details = await fetch_recipe_details(recipe.name)
+    if details:
+        recipe = schemas.RecipeCreate(**details)
     return crud.create_recipe(db, recipe)

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -27,7 +27,12 @@ def get_recipe(db: Session, recipe_id: int):
 
 
 def create_recipe(db: Session, recipe: schemas.RecipeCreate):
-    db_obj = models.Recipe(**recipe.model_dump())
+    data = recipe.model_dump(exclude={"tags", "categories", "ibas", "ingredients"})
+    db_obj = models.Recipe(**data)
+    db_obj.tags = [models.Tag(name=t) for t in recipe.tags]
+    db_obj.categories = [models.Category(name=c) for c in recipe.categories]
+    db_obj.ibas = [models.Iba(name=i) for i in recipe.ibas]
+    db_obj.ingredients = [models.RecipeIngredient(name=i.name, measure=i.measure) for i in recipe.ingredients]
     db.add(db_obj)
     db.commit()
     db.refresh(db_obj)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -18,6 +18,55 @@ class Recipe(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
+    alcoholic = Column(String, nullable=True)
+    instructions = Column(String, nullable=True)
+    thumb = Column(String, nullable=True)
+
+    tags = relationship("Tag", back_populates="recipe", cascade="all, delete-orphan")
+    categories = relationship("Category", back_populates="recipe", cascade="all, delete-orphan")
+    ibas = relationship("Iba", back_populates="recipe", cascade="all, delete-orphan")
+    ingredients = relationship("RecipeIngredient", back_populates="recipe", cascade="all, delete-orphan")
+
+
+class Tag(Base):
+    __tablename__ = "tags"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    recipe_id = Column(Integer, ForeignKey("recipes.id"), nullable=False)
+
+    recipe = relationship("Recipe", back_populates="tags")
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    recipe_id = Column(Integer, ForeignKey("recipes.id"), nullable=False)
+
+    recipe = relationship("Recipe", back_populates="categories")
+
+
+class Iba(Base):
+    __tablename__ = "ibas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    recipe_id = Column(Integer, ForeignKey("recipes.id"), nullable=False)
+
+    recipe = relationship("Recipe", back_populates="ibas")
+
+
+class RecipeIngredient(Base):
+    __tablename__ = "recipe_ingredients"
+
+    id = Column(Integer, primary_key=True, index=True)
+    recipe_id = Column(Integer, ForeignKey("recipes.id"), nullable=False)
+    name = Column(String, nullable=False)
+    measure = Column(String, nullable=True)
+
+    recipe = relationship("Recipe", back_populates="ingredients")
 
 
 class InventoryItem(Base):

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 
 class IngredientBase(BaseModel):
     name: str
@@ -18,12 +18,57 @@ class Ingredient(IngredientBase):
 
 class RecipeBase(BaseModel):
     name: str
+    alcoholic: Optional[str] = None
+    instructions: Optional[str] = None
+    thumb: Optional[str] = None
+
+class RecipeIngredientBase(BaseModel):
+    name: str
+    measure: Optional[str] = None
+
+class RecipeIngredientCreate(RecipeIngredientBase):
+    pass
+
+class RecipeIngredient(RecipeIngredientBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class Tag(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
+class Category(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
+class Iba(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+
 
 class RecipeCreate(RecipeBase):
-    pass
+    tags: List[str] = []
+    categories: List[str] = []
+    ibas: List[str] = []
+    ingredients: List[RecipeIngredientCreate] = []
 
 class Recipe(RecipeBase):
     id: int
+    tags: List[Tag] = []
+    categories: List[Category] = []
+    ibas: List[Iba] = []
+    ingredients: List[RecipeIngredient] = []
 
     class Config:
         orm_mode = True

--- a/backend/app/services/cocktaildb.py
+++ b/backend/app/services/cocktaildb.py
@@ -25,3 +25,36 @@ async def search_recipes(name: str) -> list[str]:
         data = resp.json()
         drinks = data.get("drinks") or []
         return [d.get("strDrink") for d in drinks if d.get("strDrink")]
+
+
+async def fetch_recipe_details(name: str) -> dict | None:
+    """Fetch detailed recipe information for the first matching drink."""
+    url = f"{API_BASE}/search.php"
+    params = {"s": name}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        drinks = data.get("drinks")
+        if not drinks:
+            return None
+        d = drinks[0]
+        tags = [t.strip() for t in (d.get("strTags") or "").split(",") if t.strip()]
+        categories = [c.strip() for c in (d.get("strCategory") or "").split(",") if c.strip()]
+        ibas = [i.strip() for i in (d.get("strIBA") or "").split(",") if i.strip()]
+        ingredients = []
+        for i in range(1, 16):
+            ing = d.get(f"strIngredient{i}")
+            meas = d.get(f"strMeasure{i}")
+            if ing:
+                ingredients.append({"name": ing, "measure": meas})
+        return {
+            "name": d.get("strDrink"),
+            "alcoholic": d.get("strAlcoholic"),
+            "instructions": d.get("strInstructions"),
+            "thumb": d.get("strDrinkThumb"),
+            "tags": tags,
+            "categories": categories,
+            "ibas": ibas,
+            "ingredients": ingredients,
+        }

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -64,9 +64,18 @@ async def test_create_and_list_ingredient(async_client):
 @pytest.mark.asyncio
 async def test_create_recipe(monkeypatch, async_client):
     async def fake_fetch(name: str):
-        return "Mojito"
+        return {
+            "name": "Mojito",
+            "alcoholic": "Alcoholic",
+            "instructions": "Mix it",
+            "thumb": "http://example.com/mojito.jpg",
+            "tags": ["Classic"],
+            "categories": ["Cocktail"],
+            "ibas": ["New Era"],
+            "ingredients": [{"name": "Rum", "measure": "2 oz"}],
+        }
 
-    monkeypatch.setattr("backend.app.services.cocktaildb.fetch_recipe_name", fake_fetch)
+    monkeypatch.setattr("backend.app.services.cocktaildb.fetch_recipe_details", fake_fetch)
     resp = await async_client.post("/recipes/", json={"name": "mojito"})
     assert resp.status_code == 201
     assert resp.json()["name"] == "Mojito"
@@ -81,7 +90,10 @@ async def test_recipe_search(monkeypatch, async_client):
     monkeypatch.setattr("backend.app.api.recipes.search_recipes", fake_search)
     resp = await async_client.get("/recipes/search", params={"q": "margarita"})
     assert resp.status_code == 200
-    assert resp.json() == [{"name": "Margarita"}, {"name": "Blue Margarita"}]
+    assert resp.json() == [
+        {"name": "Margarita", "alcoholic": None, "instructions": None, "thumb": None},
+        {"name": "Blue Margarita", "alcoholic": None, "instructions": None, "thumb": None},
+    ]
 
 
 @pytest.mark.asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "fastapi (>=0.116.0,<0.117.0)",
     "uvicorn[standard] (>=0.35.0,<0.36.0)",
     "sqlalchemy (>=2.0.41,<3.0.0)",
-    "pydantic (>=2.11.7,<3.0.0)"
+    "pydantic (>=2.11.7,<3.0.0)",
+    "httpx (>=0.27.0,<0.28.0)"
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.116.0,<0.117.0
 uvicorn[standard]>=0.35.0,<0.36.0
 sqlalchemy>=2.0.41,<3.0.0
 pydantic>=2.11.7,<3.0.0
+httpx>=0.27.0,<0.28.0


### PR DESCRIPTION
## Summary
- include httpx dependency
- create Tag, Category, Iba and RecipeIngredient tables
- extend Recipe model with extra metadata
- fetch detailed recipe data from the CocktailDB API
- adjust recipe creation endpoint and tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702dd2d87c83308ce4baa6d33ec581