### PR TITLE
Enable recipe details and clickable saved recipes

### DIFF
--- a/backend/app/services/cocktaildb.py
+++ b/backend/app/services/cocktaildb.py
@@ -27,6 +27,28 @@ async def search_recipes(name: str) -> list[str]:
         return [d.get("strDrink") for d in drinks if d.get("strDrink")]
 
 
+async def search_recipes_details(name: str) -> list[dict]:
+    """Return basic recipe information for matches."""
+    url = f"{API_BASE}/search.php"
+    params = {"s": name}
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        drinks = data.get("drinks") or []
+        results = []
+        for d in drinks:
+            results.append(
+                {
+                    "name": d.get("strDrink"),
+                    "alcoholic": d.get("strAlcoholic"),
+                    "instructions": d.get("strInstructions"),
+                    "thumb": d.get("strDrinkThumb"),
+                }
+            )
+        return results
+
+
 async def fetch_recipe_details(name: str) -> dict | None:
     """Fetch detailed recipe information for the first matching drink."""
     url = f"{API_BASE}/search.php"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Inventory from './pages/Inventory';
 import Recipes from './pages/Recipes';
+import RecipeDetail from './pages/RecipeDetail';
 import ShoppingList from './pages/ShoppingList';
 import Stats from './pages/Stats';
 import { healthCheck } from './api';
@@ -28,6 +29,7 @@ export default function App() {
           <Route path="/" element={<Dashboard />} />
           <Route path="/inventory" element={<Inventory />} />
           <Route path="/recipes" element={<Recipes />} />
+          <Route path="/recipes/:id" element={<RecipeDetail />} />
           <Route path="/shopping-list" element={<ShoppingList />} />
           <Route path="/stats" element={<Stats />} />
         </Routes>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -60,6 +60,14 @@ export async function searchRecipes(q: string) {
   return res.json();
 }
 
+export async function getRecipe(id: number) {
+  const res = await fetch(`${API_BASE}/recipes/${id}`);
+  if (!res.ok) {
+    throw new Error('Recipe not found');
+  }
+  return res.json();
+}
+
 export async function createRecipe(data: { name: string }) {
   const res = await fetch(`${API_BASE}/recipes/`, {
     method: 'POST',

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getRecipe } from '../api';
+
+interface Ingredient {
+  id: number;
+  name: string;
+  measure?: string | null;
+}
+
+interface Recipe {
+  id: number;
+  name: string;
+  instructions?: string | null;
+  thumb?: string | null;
+  ingredients?: Ingredient[];
+}
+
+export default function RecipeDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [recipe, setRecipe] = useState<Recipe | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    getRecipe(parseInt(id))
+      .then(setRecipe)
+      .catch(() => setRecipe(null));
+  }, [id]);
+
+  if (!recipe) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{recipe.name}</h1>
+      {recipe.thumb && (
+        <img src={recipe.thumb} alt={recipe.name} className="w-48" />
+      )}
+      {recipe.instructions && <p>{recipe.instructions}</p>}
+      {recipe.ingredients && recipe.ingredients.length > 0 && (
+        <div>
+          <h2 className="font-semibold">Ingredients</h2>
+          <ul className="list-disc pl-5">
+            {recipe.ingredients.map((ing) => (
+              <li key={ing.id}>
+                {ing.measure ? `${ing.measure} ` : ''}
+                {ing.name}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react';
 import { listRecipes, searchRecipes, createRecipe } from '../api';
+import { Link } from 'react-router-dom';
 
 interface Recipe {
-  name: string;
   id?: number;
+  name: string;
+  alcoholic?: string | null;
+  instructions?: string | null;
+  thumb?: string | null;
 }
 
 export default function Recipes() {
@@ -49,14 +53,22 @@ export default function Recipes() {
           <h2 className="font-semibold">Results</h2>
           <ul className="list-disc pl-5">
             {results.map((r) => (
-              <li key={r.name} className="my-1 flex items-center space-x-2">
-                <span>{r.name}</span>
-                <button
-                  onClick={() => save(r.name)}
-                  className="rounded bg-green-500 px-1 text-white"
-                >
-                  Add
-                </button>
+              <li key={r.name} className="my-1 space-y-1">
+                <div className="flex items-center space-x-2">
+                  <span className="font-semibold">{r.name}</span>
+                  <button
+                    onClick={() => save(r.name)}
+                    className="rounded bg-green-500 px-1 text-white"
+                  >
+                    Add
+                  </button>
+                </div>
+                {r.thumb && (
+                  <img src={r.thumb} alt={r.name} className="w-32" />
+                )}
+                {r.instructions && (
+                  <p className="text-sm text-gray-700">{r.instructions}</p>
+                )}
               </li>
             ))}
           </ul>
@@ -67,7 +79,15 @@ export default function Recipes() {
           <h2 className="font-semibold">Saved Recipes</h2>
           <ul className="list-disc pl-5">
             {saved.map((s) => (
-              <li key={s.id || s.name}>{s.name}</li>
+              <li key={s.id || s.name}>
+                {s.id ? (
+                  <Link to={`/recipes/${s.id}`} className="text-blue-600 underline">
+                    {s.name}
+                  </Link>
+                ) : (
+                  s.name
+                )}
+              </li>
             ))}
           </ul>
         </div>

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -39,6 +39,15 @@ paths:
             type: integer
     post:
       summary: Add recipe from CocktailDB
+  /recipes/{recipe_id}:
+    get:
+      summary: Get recipe
+      parameters:
+        - in: path
+          name: recipe_id
+          required: true
+          schema:
+            type: integer
   /inventory/{id}:
     get:
       summary: Get inventory item


### PR DESCRIPTION
## Summary
- expand CocktailDB service to provide recipe details
- expose recipe detail endpoint in backend API
- document new `/recipes/{recipe_id}` path
- support fetching a single recipe in the frontend API helpers
- add page to show recipe details
- display instructions and thumbnails in search results
- link saved recipes to the detail page
- adjust backend tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68703065a5ec833091f02f5743797d41