### PR TITLE
Import recipe ingredients into inventory

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -35,4 +35,6 @@ async def create_recipe(recipe: schemas.RecipeCreate, db: Session = Depends(sess
     details = await fetch_recipe_details(recipe.name)
     if details:
         recipe = schemas.RecipeCreate(**details)
-    return crud.create_recipe(db, recipe)
+    db_recipe = crud.create_recipe(db, recipe)
+    crud.ensure_inventory_for_ingredients(db, recipe.ingredients)
+    return db_recipe

--- a/backend/app/services/synonyms.py
+++ b/backend/app/services/synonyms.py
@@ -1,0 +1,13 @@
+ALIASES = {
+    "dark rum": "Rum",
+    "white rum": "Rum",
+    "fresh lime juice": "Lime juice",
+}
+
+
+def canonical_name(name: str) -> str:
+    """Return a normalized ingredient name using known aliases."""
+    key = name.strip().lower()
+    if key in ALIASES:
+        return ALIASES[key]
+    return name.strip().title()


### PR DESCRIPTION
## Summary
- create synonym helper to normalize ingredient names
- deduplicate ingredients during creation and import
- automatically add recipe ingredients to the inventory
- test inventory import and ingredient deduplication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68709eb50b10833092a839a8751815a1