### PR TITLE
Add synonyms management UI and API

### DIFF
--- a/backend/app/api/synonyms.py
+++ b/backend/app/api/synonyms.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, HTTPException
+
+from ..services import synonyms
+from ..db import schemas
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[schemas.Synonym])
+def list_synonyms():
+    return synonyms.list_synonyms()
+
+
+@router.post("/", response_model=schemas.Synonym, status_code=201)
+def create_synonym(s: schemas.Synonym):
+    if not s.alias or not s.canonical:
+        raise HTTPException(status_code=400, detail="Invalid data")
+    return synonyms.add_synonym(s.alias, s.canonical)
+
+
+@router.delete("/{alias}", status_code=204)
+def delete_synonym(alias: str):
+    synonyms.delete_synonym(alias)
+    return None

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -94,3 +94,8 @@ class InventoryItem(InventoryItemBase):
 
 class InventoryItemWithIngredient(InventoryItem):
     ingredient: Ingredient
+
+
+class Synonym(BaseModel):
+    alias: str
+    canonical: str

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 import logging
 
-from .api import ingredients, recipes, inventory, barcode
+from .api import ingredients, recipes, inventory, barcode, synonyms
 
 app = FastAPI(title="Bar Management")
 
@@ -40,4 +40,5 @@ app.include_router(ingredients.router, prefix="/ingredients")
 app.include_router(recipes.router, prefix="/recipes")
 app.include_router(inventory.router, prefix="/inventory")
 app.include_router(barcode.router, prefix="/barcode")
+app.include_router(synonyms.router, prefix="/synonyms")
 

--- a/backend/app/services/synonyms.json
+++ b/backend/app/services/synonyms.json
@@ -1,0 +1,5 @@
+{
+  "dark rum": "Rum",
+  "white rum": "Rum",
+  "fresh lime juice": "Lime juice"
+}

--- a/backend/app/services/synonyms.py
+++ b/backend/app/services/synonyms.py
@@ -1,8 +1,47 @@
-ALIASES = {
-    "dark rum": "Rum",
-    "white rum": "Rum",
-    "fresh lime juice": "Lime juice",
-}
+"""Manage ingredient synonym mappings."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_FILE = Path(__file__).with_name("synonyms.json")
+
+try:
+    with _FILE.open() as f:
+        ALIASES: dict[str, str] = json.load(f)
+except FileNotFoundError:  # pragma: no cover - default when file missing
+    ALIASES = {
+        "dark rum": "Rum",
+        "white rum": "Rum",
+        "fresh lime juice": "Lime juice",
+    }
+    with _FILE.open("w") as f:  # ensure default file exists
+        json.dump(ALIASES, f, indent=2)
+
+
+def _save() -> None:
+    with _FILE.open("w") as f:
+        json.dump(ALIASES, f, indent=2)
+
+
+def list_synonyms() -> list[dict[str, str]]:
+    """Return all known aliases."""
+    return [{"alias": a, "canonical": c} for a, c in ALIASES.items()]
+
+
+def add_synonym(alias: str, canonical: str) -> dict[str, str]:
+    """Add or update a synonym mapping."""
+    ALIASES[alias.strip().lower()] = canonical.strip().title()
+    _save()
+    return {"alias": alias.strip().lower(), "canonical": canonical.strip().title()}
+
+
+def delete_synonym(alias: str) -> None:
+    """Remove a synonym if present."""
+    ALIASES.pop(alias.strip().lower(), None)
+    _save()
 
 
 def canonical_name(name: str) -> str:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -225,3 +225,26 @@ async def test_ingredient_deduplication(monkeypatch, async_client):
     names = [i["name"] for i in ingredients]
     assert "Dark Rum" not in names
     assert "Rum" in names
+
+
+@pytest.mark.asyncio
+async def test_synonym_crud(async_client):
+    resp = await async_client.get("/synonyms/")
+    assert resp.status_code == 200
+    initial = len(resp.json())
+
+    resp = await async_client.post(
+        "/synonyms/",
+        json={"alias": "whisky", "canonical": "Whiskey"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["canonical"] == "Whiskey"
+
+    resp = await async_client.get("/synonyms/")
+    assert len(resp.json()) == initial + 1
+
+    resp = await async_client.delete("/synonyms/whisky")
+    assert resp.status_code == 204
+
+    resp = await async_client.get("/synonyms/")
+    assert len(resp.json()) == initial

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Recipes from './pages/Recipes';
 import RecipeDetail from './pages/RecipeDetail';
 import ShoppingList from './pages/ShoppingList';
 import Stats from './pages/Stats';
+import Synonyms from './pages/Synonyms';
 import { healthCheck } from './api';
 import Navbar from './components/Navbar';
 import './App.css';
@@ -32,6 +33,7 @@ export default function App() {
           <Route path="/recipes/:id" element={<RecipeDetail />} />
           <Route path="/shopping-list" element={<ShoppingList />} />
           <Route path="/stats" element={<Stats />} />
+          <Route path="/synonyms" element={<Synonyms />} />
         </Routes>
       </main>
     </Router>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -76,3 +76,23 @@ export async function createRecipe(data: { name: string }) {
   });
   return res.json();
 }
+
+export async function listSynonyms() {
+  const res = await fetch(`${API_BASE}/synonyms/`);
+  return res.json();
+}
+
+export async function addSynonym(alias: string, canonical: string) {
+  const res = await fetch(`${API_BASE}/synonyms/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ alias, canonical }),
+  });
+  return res.json();
+}
+
+export async function deleteSynonym(alias: string) {
+  await fetch(`${API_BASE}/synonyms/${encodeURIComponent(alias)}`, {
+    method: 'DELETE',
+  });
+}

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -11,7 +11,7 @@ export default function BarcodeScanner({ onDetected }: { onDetected: (code: stri
         inputStream: { type: 'LiveStream', target: ref.current },
         decoder: { readers: ['ean_reader'] }
       },
-      (err) => {
+      (err: unknown) => {
         if (err) {
           console.error(err)
           return
@@ -19,7 +19,7 @@ export default function BarcodeScanner({ onDetected }: { onDetected: (code: stri
         Quagga.start()
       }
     )
-    Quagga.onDetected((res) => {
+    Quagga.onDetected((res: any) => {
       onDetected(res.codeResult.code)
       Quagga.stop()
     })

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -22,6 +22,9 @@ export default function Navbar() {
         <NavLink to="/stats" className={linkClass}>
           Stats
         </NavLink>
+        <NavLink to="/synonyms" className={linkClass}>
+          Synonyms
+        </NavLink>
       </nav>
     </header>
   );

--- a/frontend/src/pages/Synonyms.tsx
+++ b/frontend/src/pages/Synonyms.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { listSynonyms, addSynonym, deleteSynonym } from '../api';
+
+interface Synonym {
+  alias: string;
+  canonical: string;
+}
+
+export default function Synonyms() {
+  const [synonyms, setSynonyms] = useState<Synonym[]>([]);
+  const [alias, setAlias] = useState('');
+  const [canonical, setCanonical] = useState('');
+
+  const refresh = () => {
+    listSynonyms().then(setSynonyms);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const submit = async () => {
+    if (!alias || !canonical) return;
+    await addSynonym(alias, canonical);
+    setAlias('');
+    setCanonical('');
+    refresh();
+  };
+
+  const remove = async (a: string) => {
+    await deleteSynonym(a);
+    setSynonyms(synonyms.filter((s) => s.alias !== a));
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Synonyms</h1>
+      <div className="space-x-2">
+        <input
+          placeholder="Alias"
+          value={alias}
+          onChange={(e) => setAlias(e.target.value)}
+          className="border p-1"
+        />
+        <input
+          placeholder="Canonical"
+          value={canonical}
+          onChange={(e) => setCanonical(e.target.value)}
+          className="border p-1"
+        />
+        <button onClick={submit} className="rounded bg-blue-500 px-2 py-1 text-white">
+          Add
+        </button>
+      </div>
+      <table className="min-w-full border text-left">
+        <thead>
+          <tr>
+            <th className="px-2">Alias</th>
+            <th className="px-2">Canonical</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {synonyms.map((s) => (
+            <tr key={s.alias} className="border-t">
+              <td className="px-2 py-1">{s.alias}</td>
+              <td className="px-2 py-1">{s.canonical}</td>
+              <td className="px-2 py-1">
+                <button onClick={() => remove(s.alias)} className="text-red-600">
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -55,8 +55,16 @@ paths:
         - in: path
           name: id
           required: true
-          schema:
-            type: integer
+      schema:
+        type: integer
+  /synonyms:
+    get:
+      summary: List synonyms
+    post:
+      summary: Create synonym
+  /synonyms/{alias}:
+    delete:
+      summary: Delete synonym
     patch:
       summary: Update inventory item
       parameters:


### PR DESCRIPTION
## Summary
- handle synonyms in backend via JSON file
- expose new `/synonyms` API with CRUD endpoints
- add Synonym schema and tests for new endpoints
- build UI page to manage ingredient synonyms
- update navigation and API helpers

## Testing
- `pytest -q`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870a20fa430833083b345af056d21e6