### PR TITLE
Apply style guide colors to header

### DIFF
--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -19,7 +19,7 @@ export default function BarcodeScanner({ onDetected }: { onDetected: (code: stri
         Quagga.start()
       }
     )
-    Quagga.onDetected((res: any) => {
+    Quagga.onDetected((res: QuaggaJSResultObject) => {
       onDetected(res.codeResult.code)
       Quagga.stop()
     })

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,10 +2,12 @@ import { NavLink } from 'react-router-dom';
 
 export default function Navbar() {
   const linkClass = ({ isActive }: { isActive: boolean }) =>
-    isActive ? 'text-white font-semibold' : 'text-gray-300 hover:text-white';
+    isActive
+      ? 'text-[var(--accent)] font-semibold'
+      : 'text-[var(--text-muted)] hover:text-[var(--text-primary)]';
 
   return (
-    <header className="bg-gray-800">
+    <header className="bg-[var(--bg-elevated)] border-b border-[var(--border)] text-[var(--text-primary)]">
       <nav className="container mx-auto flex items-center space-x-4 p-4">
         <NavLink to="/" className={linkClass} end>
           Dashboard

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,20 @@
+:root {
+  --bg-primary:   #0E0E0F;
+  --bg-elevated:  #1A1B1D;
+  --border:       #2C2D30;
+  --text-primary: #E6E6E8;
+  --text-muted:   #9A9A9F;
+  --accent:       #FFB248;
+  --success:      #27C192;
+  --danger:       #FF5160;
+  --highlight:    #725AF0;
+}
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}


### PR DESCRIPTION
## Summary
- add global CSS variables for the "Smoky Speakeasy" palette
- use the dark palette in the Navbar header
- fix `BarcodeScanner` type for ESLint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870d3801e488330b229cbc275360daa