### PR TITLE
Modern dashboard design

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:wght@600&display=swap" rel="stylesheet" />
     <title>BarTool</title>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "lucide-react": "^0.525.0",
         "quagga": "^0.12.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -4707,6 +4708,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "lucide-react": "^0.525.0",
     "quagga": "^0.12.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+interface CardProps {
+  title: string;
+  to: string;
+  icon?: ReactNode;
+  children?: ReactNode;
+}
+
+export default function Card({ title, to, icon, children }: CardProps) {
+  return (
+    <Link
+      to={to}
+      className="card block rounded-brand shadow-brand transition hover:bg-[var(--bg-elevated)]/80"
+    >
+      <div className="flex items-center gap-2 text-lg font-semibold">
+        {icon}
+        {title}
+      </div>
+      {children && (
+        <p className="mt-2 text-sm text-[var(--text-muted)]">{children}</p>
+      )}
+    </Link>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,11 @@
   --success:      #27C192;
   --danger:       #FF5160;
   --highlight:    #725AF0;
+  --brand-radius: 6px;
+  --brand-shadow: 0 4px 12px rgba(0,0,0,.40);
+  --space-4: 16px;
+  --font-display: "Playfair Display", serif;
+  --font-sans: "Inter", "Helvetica Neue", sans-serif;
 }
 
 @tailwind base;
@@ -17,4 +22,16 @@
 body {
   background-color: var(--bg-primary);
   color: var(--text-primary);
+  font-family: var(--font-sans);
+}
+
+.font-display {
+  font-family: var(--font-display);
+}
+
+.card {
+  background: var(--bg-elevated);
+  border-radius: var(--brand-radius);
+  box-shadow: var(--brand-shadow);
+  padding: var(--space-4);
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,8 +1,23 @@
+import Card from '../components/Card';
+import { Box, BookOpen, ClipboardList, BarChart2 } from 'lucide-react';
+
 export default function Dashboard() {
+  const features = [
+    { to: '/inventory', title: 'Inventory', icon: <Box size={20} /> },
+    { to: '/recipes', title: 'Recipes', icon: <BookOpen size={20} /> },
+    { to: '/shopping-list', title: 'Shopping List', icon: <ClipboardList size={20} /> },
+    { to: '/stats', title: 'Stats', icon: <BarChart2 size={20} /> },
+  ];
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
-      <p>Welcome to BarTool. Use the navigation above to manage your bar.</p>
+    <div className="space-y-6">
+      <h1 className="font-display text-3xl font-semibold">Dashboard</h1>
+      <p className="text-[var(--text-muted)]">Welcome to BarTool. Select an action below.</p>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {features.map((f) => (
+          <Card key={f.to} title={f.title} to={f.to} icon={f.icon} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,11 +1,32 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}"
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'bg-primary': '#0E0E0F',
+        'bg-elevated': '#1A1B1D',
+        border: '#2C2D30',
+        accent: '#FFB248',
+        success: '#27C192',
+        danger: '#FF5160',
+        highlight: '#725AF0',
+      },
+      borderRadius: {
+        brand: '6px',
+      },
+      boxShadow: {
+        brand: '0 4px 12px rgba(0,0,0,.40)',
+      },
+      fontFamily: {
+        display: ['"Playfair Display"', 'serif'],
+        sans: ['Inter', '"Helvetica Neue"', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
## Summary
- extend Tailwind config with theme colors and fonts from style guide
- add global CSS variables and card styling
- include Google fonts in HTML
- create reusable `Card` component
- redesign Dashboard with feature cards and Lucide icons
- add `lucide-react` dependency

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f3423088833093a84db92ee4ec27