### PR TITLE
Tune dark theme colors

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,6 @@
 :root {
-  --bg-primary:   #0E0E0F;
-  --bg-elevated:  #1A1B1D;
+  --bg-primary:   #1A1B1D;
+  --bg-elevated:  #242526;
   --border:       #2C2D30;
   --text-primary: #E6E6E8;
   --text-muted:   #9A9A9F;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,8 +8,8 @@ export default {
   theme: {
     extend: {
       colors: {
-        'bg-primary': '#0E0E0F',
-        'bg-elevated': '#1A1B1D',
+        'bg-primary': '#1A1B1D',
+        'bg-elevated': '#242526',
         border: '#2C2D30',
         accent: '#FFB248',
         success: '#27C192',

--- a/style_guide.md
+++ b/style_guide.md
@@ -20,8 +20,8 @@ A concise but complete set of tokens, scales, and component rules for building t
 
 ```css
 /* Core surfaces */
---bg-primary:       #0E0E0F;
---bg-elevated:      #1A1B1D;
+--bg-primary:       #1A1B1D;
+--bg-elevated:      #242526;
 --border:           #2C2D30;
 
 /* Text */
@@ -168,8 +168,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'bg-primary':  '#0E0E0F',
-        'bg-elevated': '#1A1B1D',
+        'bg-primary':  '#1A1B1D',
+        'bg-elevated': '#242526',
         border:        '#2C2D30',
         accent:        '#FFB248',
         success:       '#27C192',


### PR DESCRIPTION
## Summary
- lighten background colors to reduce the harshness of the dark theme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f6e4d7788330860af7264e9ecfa2