### PR TITLE
Add inventory-aware recipe search

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -15,6 +15,26 @@ router = APIRouter()
 async def search_recipes_endpoint(q: str):
     return await search_recipes_details(q)
 
+
+@router.get("/find", response_model=list[schemas.Recipe])
+def find_recipes(
+    q: str | None = None,
+    available_only: bool = False,
+    order_missing: bool = False,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(session.get_db),
+):
+    """Search recipes stored locally with optional inventory filters."""
+    return crud.search_local_recipes(
+        db,
+        query=q,
+        available_only=available_only,
+        order_missing=order_missing,
+        skip=skip,
+        limit=limit,
+    )
+
 @router.get("/", response_model=list[schemas.Recipe])
 def list_recipes(skip: int = 0, limit: int = 100, db: Session = Depends(session.get_db)):
     return crud.list_recipes(db, skip=skip, limit=limit)

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -25,6 +25,30 @@ paths:
           name: q
           schema:
             type: string
+  /recipes/find:
+    get:
+      summary: Search local recipes
+      parameters:
+        - in: query
+          name: q
+          schema:
+            type: string
+        - in: query
+          name: available_only
+          schema:
+            type: boolean
+        - in: query
+          name: order_missing
+          schema:
+            type: boolean
+        - in: query
+          name: skip
+          schema:
+            type: integer
+        - in: query
+          name: limit
+          schema:
+            type: integer
   /recipes:
     get:
       summary: List recipes


### PR DESCRIPTION
## Summary
- add new endpoint `/recipes/find` for inventory-aware local search
- implement helpers to rank recipes by missing ingredients
- extend OpenAPI docs for new search options
- test recipe search with inventory filters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687144ec0c908330937d3fe01b467589