### PR TITLE
Add recipe finder page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,22 +1,23 @@
-import { useEffect, useState } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Dashboard from './pages/Dashboard';
-import Inventory from './pages/Inventory';
-import Recipes from './pages/Recipes';
-import RecipeDetail from './pages/RecipeDetail';
-import ShoppingList from './pages/ShoppingList';
-import Stats from './pages/Stats';
-import Synonyms from './pages/Synonyms';
-import { healthCheck } from './api';
-import Navbar from './components/Navbar';
-import './App.css';
+import { useEffect, useState } from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import Dashboard from "./pages/Dashboard";
+import Inventory from "./pages/Inventory";
+import Recipes from "./pages/Recipes";
+import FindRecipes from "./pages/FindRecipes";
+import RecipeDetail from "./pages/RecipeDetail";
+import ShoppingList from "./pages/ShoppingList";
+import Stats from "./pages/Stats";
+import Synonyms from "./pages/Synonyms";
+import { healthCheck } from "./api";
+import Navbar from "./components/Navbar";
+import "./App.css";
 
 export default function App() {
   const [health, setHealth] = useState<string | null>(null);
   useEffect(() => {
     healthCheck()
       .then((res) => setHealth(res.status))
-      .catch(() => setHealth('error'));
+      .catch(() => setHealth("error"));
   }, []);
 
   return (
@@ -30,6 +31,7 @@ export default function App() {
           <Route path="/" element={<Dashboard />} />
           <Route path="/inventory" element={<Inventory />} />
           <Route path="/recipes" element={<Recipes />} />
+          <Route path="/recipes/find" element={<FindRecipes />} />
           <Route path="/recipes/:id" element={<RecipeDetail />} />
           <Route path="/shopping-list" element={<ShoppingList />} />
           <Route path="/stats" element={<Stats />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,9 +1,9 @@
-const API_BASE = import.meta.env.VITE_API_BASE || '';
+const API_BASE = import.meta.env.VITE_API_BASE || "";
 
 export async function healthCheck() {
   const res = await fetch(`${API_BASE}/healthz`);
   if (!res.ok) {
-    throw new Error('Network error');
+    throw new Error("Network error");
   }
   return res.json();
 }
@@ -15,33 +15,39 @@ export async function listInventory() {
 
 export async function createIngredient(data: { name: string }) {
   const res = await fetch(`${API_BASE}/ingredients/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
   return res.json();
 }
 
-export async function createInventory(data: { ingredient_id: number; quantity: number }) {
+export async function createInventory(data: {
+  ingredient_id: number;
+  quantity: number;
+}) {
   const res = await fetch(`${API_BASE}/inventory/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
   return res.json();
 }
 
-export async function updateInventory(id: number, data: { quantity?: number; status?: string }) {
+export async function updateInventory(
+  id: number,
+  data: { quantity?: number; status?: string },
+) {
   const res = await fetch(`${API_BASE}/inventory/${id}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
   return res.json();
 }
 
 export async function deleteInventory(id: number) {
-  await fetch(`${API_BASE}/inventory/${id}`, { method: 'DELETE' });
+  await fetch(`${API_BASE}/inventory/${id}`, { method: "DELETE" });
 }
 
 export async function lookupBarcode(ean: string) {
@@ -56,22 +62,47 @@ export async function listRecipes() {
 }
 
 export async function searchRecipes(q: string) {
-  const res = await fetch(`${API_BASE}/recipes/search?q=${encodeURIComponent(q)}`);
+  const res = await fetch(
+    `${API_BASE}/recipes/search?q=${encodeURIComponent(q)}`,
+  );
+  return res.json();
+}
+
+export interface FindRecipesOptions {
+  q?: string;
+  available_only?: boolean;
+  order_missing?: boolean;
+  skip?: number;
+  limit?: number;
+}
+
+export async function findRecipes(options: FindRecipesOptions = {}) {
+  const params = new URLSearchParams();
+  if (options.q) params.append("q", options.q);
+  if (options.available_only) params.append("available_only", "true");
+  if (options.order_missing) params.append("order_missing", "true");
+  if (options.skip !== undefined) params.append("skip", String(options.skip));
+  if (options.limit !== undefined)
+    params.append("limit", String(options.limit));
+  const query = params.toString();
+  const res = await fetch(
+    `${API_BASE}/recipes/find${query ? `?${query}` : ""}`,
+  );
   return res.json();
 }
 
 export async function getRecipe(id: number) {
   const res = await fetch(`${API_BASE}/recipes/${id}`);
   if (!res.ok) {
-    throw new Error('Recipe not found');
+    throw new Error("Recipe not found");
   }
   return res.json();
 }
 
 export async function createRecipe(data: { name: string }) {
   const res = await fetch(`${API_BASE}/recipes/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
   return res.json();
@@ -84,8 +115,8 @@ export async function listSynonyms() {
 
 export async function addSynonym(alias: string, canonical: string) {
   const res = await fetch(`${API_BASE}/synonyms/`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ alias, canonical }),
   });
   return res.json();
@@ -93,6 +124,6 @@ export async function addSynonym(alias: string, canonical: string) {
 
 export async function deleteSynonym(alias: string) {
   await fetch(`${API_BASE}/synonyms/${encodeURIComponent(alias)}`, {
-    method: 'DELETE',
+    method: "DELETE",
   });
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,13 +1,13 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink } from "react-router-dom";
 
 export default function Navbar() {
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     [
-      'px-3 py-2 rounded-brand font-medium transition-colors',
+      "px-3 py-2 rounded-brand font-medium transition-colors",
       isActive
-        ? 'bg-[var(--accent)] text-black'
-        : 'text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-primary)]',
-    ].join(' ');
+        ? "bg-[var(--accent)] text-black"
+        : "text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-primary)]",
+    ].join(" ");
 
   return (
     <header className="bg-[var(--bg-elevated)] border-b border-[var(--border)] text-[var(--text-primary)]">
@@ -20,6 +20,9 @@ export default function Navbar() {
         </NavLink>
         <NavLink to="/recipes" className={linkClass}>
           Recipes
+        </NavLink>
+        <NavLink to="/recipes/find" className={linkClass}>
+          Recipe Finder
         </NavLink>
         <NavLink to="/shopping-list" className={linkClass}>
           Shopping List

--- a/frontend/src/pages/FindRecipes.tsx
+++ b/frontend/src/pages/FindRecipes.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import { findRecipes } from "../api";
+import { Link } from "react-router-dom";
+import { Search } from "lucide-react";
+
+interface Recipe {
+  id: number;
+  name: string;
+  alcoholic?: string | null;
+  instructions?: string | null;
+  thumb?: string | null;
+}
+
+export default function FindRecipes() {
+  const [query, setQuery] = useState("");
+  const [availableOnly, setAvailableOnly] = useState(false);
+  const [orderMissing, setOrderMissing] = useState(false);
+  const [results, setResults] = useState<Recipe[]>([]);
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  const runSearch = async () => {
+    const data = await findRecipes({
+      q: query || undefined,
+      available_only: availableOnly,
+      order_missing: orderMissing,
+    });
+    setResults(data);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">Recipe Finder</h1>
+      <div className="flex max-w-md items-center overflow-hidden rounded border border-[var(--highlight)]">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search saved recipes"
+          className="w-full bg-transparent p-2 focus:outline-none text-[var(--text-primary)] border-none"
+        />
+        <button onClick={runSearch} className="button-send" aria-label="Search">
+          <Search size={20} />
+        </button>
+      </div>
+      <div className="flex items-center gap-4">
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={availableOnly}
+            onChange={(e) => setAvailableOnly(e.target.checked)}
+          />
+          Available only
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            type="checkbox"
+            checked={orderMissing}
+            onChange={(e) => setOrderMissing(e.target.checked)}
+          />
+          Order by missing
+        </label>
+      </div>
+      {results.length > 0 && (
+        <div className="card p-0">
+          <ul className="divide-y divide-[var(--border)]">
+            {results.map((r) => {
+              const expandedKey = expanded === r.id;
+              return (
+                <li key={r.id}>
+                  <div
+                    className="flex items-center gap-2 p-4 cursor-pointer mb-[5px] mt-[5px]"
+                    onClick={() => setExpanded(expandedKey ? null : r.id)}
+                  >
+                    <span className="flex-1 truncate font-semibold">
+                      {r.name}
+                    </span>
+                    <Link
+                      to={`/recipes/${r.id}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="button-search"
+                    >
+                      Open
+                    </Link>
+                  </div>
+                  {expandedKey && (
+                    <div className="space-y-1 p-2 text-sm text-[var(--text-muted)]">
+                      {r.thumb && (
+                        <img
+                          src={r.thumb}
+                          alt={r.name}
+                          className="h-2 w-2 rounded object-cover"
+                        />
+                      )}
+                      {r.alcoholic && <p>{r.alcoholic}</p>}
+                      {r.instructions && <p>{r.instructions}</p>}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `findRecipes` API helper for `/recipes/find`
- create `Recipe Finder` page with search form and filters
- wire new page into routes and navbar
- update formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687242537ff083308cd1175577dc3be2