### PR TITLE
Expose inventory counts in recipe finder

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -16,7 +16,7 @@ async def search_recipes_endpoint(q: str):
     return await search_recipes_details(q)
 
 
-@router.get("/find", response_model=list[schemas.Recipe])
+@router.get("/find", response_model=list[schemas.RecipeWithInventory])
 def find_recipes(
     q: str | None = None,
     available_only: bool = False,

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -73,6 +73,15 @@ class Recipe(RecipeBase):
     class Config:
         orm_mode = True
 
+
+class RecipeWithInventory(Recipe):
+    """Recipe details along with inventory availability info."""
+    available_count: int
+    missing_count: int
+
+    class Config:
+        orm_mode = True
+
 class InventoryItemBase(BaseModel):
     ingredient_id: int
     quantity: int

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -301,11 +301,19 @@ async def test_recipe_find_inventory(monkeypatch, async_client):
 
     resp = await async_client.get("/recipes/find", params={"available_only": True, "q": "vodka"})
     assert resp.status_code == 200
-    names = [r["name"] for r in resp.json()]
+    data = resp.json()
+    names = [r["name"] for r in data]
     assert "Vodka Only" in names
     assert "Vodka Gin" not in names
+    vo = next(r for r in data if r["name"] == "Vodka Only")
+    assert vo["available_count"] == 1
+    assert vo["missing_count"] == 0
 
     resp = await async_client.get("/recipes/find", params={"order_missing": True, "q": "vodka"})
     assert resp.status_code == 200
-    names = [r["name"] for r in resp.json()]
+    data = resp.json()
+    names = [r["name"] for r in data]
     assert names[0] == "Vodka Only"
+    vg = next(r for r in data if r["name"] == "Vodka Gin")
+    assert vg["available_count"] == 1
+    assert vg["missing_count"] == 1

--- a/frontend/src/pages/FindRecipes.tsx
+++ b/frontend/src/pages/FindRecipes.tsx
@@ -9,6 +9,8 @@ interface Recipe {
   alcoholic?: string | null;
   instructions?: string | null;
   thumb?: string | null;
+  available_count?: number;
+  missing_count?: number;
 }
 
 export default function FindRecipes() {
@@ -73,6 +75,11 @@ export default function FindRecipes() {
                     <span className="flex-1 truncate font-semibold">
                       {r.name}
                     </span>
+                    {typeof r.available_count === "number" && typeof r.missing_count === "number" && (
+                      <span className="text-sm text-[var(--text-secondary)]">
+                        {r.available_count} available / {r.missing_count} missing
+                      </span>
+                    )}
                     <Link
                       to={`/recipes/${r.id}`}
                       onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## Summary
- include inventory counts in recipe finder
- return new schema `RecipeWithInventory`
- show available/missing counts in frontend
- test new behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872458e8e948330a7a48074729aa078