### PR TITLE
Integrate Open Food Facts for barcode lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ BarTool is a lightweight bar management system intended to run even on a small d
 - **Inventory management** – keep an overview of all bottles and ingredients
 - **Recipe storage** – save your favourite cocktails and browse suggestions
 - **Shopping list** – collect missing items you need to buy
+- **Barcode scanning** – looks up product info via Open Food Facts
 - **Statistics dashboard** – view usage data and upcoming expiries
 
 The project is still in an early stage and focuses on a clean API structure and a minimal, responsive UI.
@@ -43,6 +44,12 @@ API has initial data to work with.
 
 Afterwards open `http://localhost:5173` in your browser.  If the backend runs on a different port, set the environment variable `VITE_API_BASE` when starting the
 frontend, e.g. `VITE_API_BASE=http://localhost:8000 npm run dev`.
+
+### Barcode lookup
+
+Scanning a bottle in the inventory page sends a request to `/barcode/{EAN}`. The
+backend queries the public **Open Food Facts** API and returns the product name,
+brand and image URL if available.
 
 ---
 

--- a/backend/app/services/barcode.py
+++ b/backend/app/services/barcode.py
@@ -17,6 +17,11 @@ async def fetch_barcode(ean: str) -> Optional[Dict]:
         data = resp.json()
         if data.get("status") != 1:
             return None
-        result = {"name": data.get("product", {}).get("product_name")}
+        product = data.get("product", {})
+        result = {
+            "name": product.get("product_name"),
+            "brand": product.get("brands"),
+            "image_url": product.get("image_front_url"),
+        }
         _cache[ean] = result
         return result

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -163,12 +163,15 @@ async def test_inventory_patch(async_client):
 @pytest.mark.asyncio
 async def test_barcode_lookup(monkeypatch, async_client):
     async def fake_lookup(ean: str):
-        return {"name": "Test"}
+        return {"name": "Test", "brand": "Foo", "image_url": "http://img"}
 
     monkeypatch.setattr("backend.app.services.barcode.fetch_barcode", fake_lookup)
     resp = await async_client.get("/barcode/123456")
     assert resp.status_code == 200
-    assert resp.json()["name"] == "Test"
+    data = resp.json()
+    assert data["name"] == "Test"
+    assert data["brand"] == "Foo"
+    assert data["image_url"] == "http://img"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -50,7 +50,13 @@ export async function deleteInventory(id: number) {
   await fetch(`${API_BASE}/inventory/${id}`, { method: "DELETE" });
 }
 
-export async function lookupBarcode(ean: string) {
+export interface BarcodeResult {
+  name: string | null
+  brand?: string | null
+  image_url?: string | null
+}
+
+export async function lookupBarcode(ean: string): Promise<BarcodeResult | null> {
   const res = await fetch(`${API_BASE}/barcode/${ean}`);
   if (!res.ok) return null;
   return res.json();

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -26,6 +26,8 @@ export default function Inventory() {
   const [items, setItems] = useState<InventoryItem[]>([])
   const [scanning, setScanning] = useState(false)
   const [name, setName] = useState('')
+  const [brand, setBrand] = useState('')
+  const [image, setImage] = useState('')
   const [quantity, setQuantity] = useState(1)
 
   const refresh = () => {
@@ -41,6 +43,8 @@ export default function Inventory() {
     const res = await lookupBarcode(code)
     if (res?.name) {
       setName(res.name)
+      setBrand(res.brand || '')
+      setImage(res.image_url || '')
     }
   }
 
@@ -49,6 +53,8 @@ export default function Inventory() {
     const ing = await createIngredient({ name })
     await createInventory({ ingredient_id: ing.id, quantity })
     setName('')
+    setBrand('')
+    setImage('')
     setQuantity(1)
     refresh()
   }
@@ -85,6 +91,10 @@ export default function Inventory() {
           onChange={(e) => setName(e.target.value)}
           className="border p-1"
         />
+        {brand && <span className="text-sm text-gray-500">{brand}</span>}
+        {image && (
+          <img src={image} alt="product" className="inline-block h-8" />
+        )}
         <input
           type="number"
           value={quantity}

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -97,3 +97,12 @@ paths:
           required: true
           schema:
             type: integer
+  /barcode/{ean}:
+    get:
+      summary: Lookup product information from Open Food Facts
+      parameters:
+        - in: path
+          name: ean
+          required: true
+          schema:
+            type: string


### PR DESCRIPTION
## Summary
- expand barcode service to fetch brand and image from Open Food Facts
- expose `/barcode/{ean}` in OpenAPI docs
- display Open Food Facts data in inventory page
- type barcode lookup result in API client
- document barcode lookup feature in README
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727adc31708330a8fe59f39161202e