### PR TITLE
Fix frontend backend path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 __pycache__/
 *.py[cod]
 venv/
+# allow the frontend environment to be versioned
 .env
+!frontend/.env
 *.egg-info/
 dist/
 # SQLite database

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ python backend/app/db/seed_db.py
 This will generate `data/seed.sqlite` and insert a few example records so the
 API has initial data to work with.
 
-Afterwards open `http://localhost:5173` in your browser.  If the backend runs on a different port, set the environment variable `VITE_API_BASE` when starting the
-frontend, e.g. `VITE_API_BASE=http://localhost:8000 npm run dev`.
+Afterwards open `http://localhost:5173` in your browser. The frontend reads the
+API base URL from `frontend/.env`, which by default contains
+`VITE_API_BASE=http://localhost:8000`. If your backend runs on a different
+host or port, adjust this value before starting the frontend with `npm run
+dev`.
 
 ### Barcode lookup
 

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE=http://localhost:8000


### PR DESCRIPTION
## Summary
- add `.env` in the frontend with API base URL
- mention the file in the README
- allow tracking `frontend/.env` via `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737910723c83309d1b27f3f979b711