### PR TITLE
Add barcode debug info

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -56,10 +56,29 @@ export interface BarcodeResult {
   image_url?: string | null
 }
 
-export async function lookupBarcode(ean: string): Promise<BarcodeResult | null> {
-  const res = await fetch(`${API_BASE}/barcode/${ean}`);
-  if (!res.ok) return null;
-  return res.json();
+export interface BarcodeDebug {
+  url: string
+  status: number
+  body: unknown
+}
+
+export interface BarcodeLookup {
+  data: BarcodeResult | null
+  debug: BarcodeDebug
+}
+
+export async function lookupBarcode(ean: string): Promise<BarcodeLookup> {
+  const url = `${API_BASE}/barcode/${ean}`
+  const res = await fetch(url)
+  const body = await res.json().catch(() => null)
+  return {
+    data: res.ok ? (body as BarcodeResult) : null,
+    debug: {
+      url,
+      status: res.status,
+      body
+    }
+  }
 }
 
 export async function listRecipes() {

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -19,7 +19,7 @@ export default function BarcodeScanner({ onDetected }: { onDetected: (code: stri
         Quagga.start()
       }
     )
-    Quagga.onDetected((res: QuaggaJSResultObject) => {
+    Quagga.onDetected((res: any) => {
       onDetected(res.codeResult.code)
       Quagga.stop()
     })

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 interface CardProps {

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -29,6 +29,7 @@ export default function Inventory() {
   const [brand, setBrand] = useState('')
   const [image, setImage] = useState('')
   const [quantity, setQuantity] = useState(1)
+  const [debug, setDebug] = useState('')
 
   const refresh = () => {
     listInventory().then(setItems)
@@ -40,11 +41,15 @@ export default function Inventory() {
 
   const onDetected = async (code: string) => {
     setScanning(false)
-    const res = await lookupBarcode(code)
-    if (res?.name) {
-      setName(res.name)
-      setBrand(res.brand || '')
-      setImage(res.image_url || '')
+    const { data, debug: dbg } = await lookupBarcode(code)
+    setDebug(
+      `GET ${dbg.url}\nStatus: ${dbg.status}\n` +
+        `Response: ${JSON.stringify(dbg.body, null, 2)}`,
+    )
+    if (data?.name) {
+      setName(data.name)
+      setBrand(data.brand || '')
+      setImage(data.image_url || '')
     }
   }
 
@@ -134,6 +139,11 @@ export default function Inventory() {
           ))}
         </tbody>
       </table>
+      {debug && (
+        <pre className="whitespace-pre-wrap bg-gray-100 p-2 text-xs">
+          {debug}
+        </pre>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- expose debug output for barcode lookups
- show last barcode API request and response in the Inventory page
- fix misc TypeScript lint issues

## Testing
- `npm run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68737bdefa788330adf6a07d5fc9be26