### PR TITLE
Add manual barcode lookup section

### DIFF
--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -8,7 +8,8 @@ import {
   deleteInventory,
   lookupBarcode,
   listIngredients,
-  listSynonyms
+  listSynonyms,
+  type BarcodeResult,
 } from '../api'
 
 interface Ingredient {
@@ -32,6 +33,8 @@ interface InventoryItem {
 export default function Inventory() {
   const [items, setItems] = useState<InventoryItem[]>([])
   const [scanning, setScanning] = useState(false)
+  const [ean, setEan] = useState('')
+  const [result, setResult] = useState<BarcodeResult | null>(null)
   const [name, setName] = useState('')
   const [brand, setBrand] = useState('')
   const [image, setImage] = useState('')
@@ -39,6 +42,7 @@ export default function Inventory() {
   const [debug, setDebug] = useState('')
   const [ingredients, setIngredients] = useState<Ingredient[]>([])
   const [synonyms, setSynonyms] = useState<Synonym[]>([])
+  const [suggested, setSuggested] = useState<Ingredient | null>(null)
 
   const synonymsMap = Object.fromEntries(
     synonyms.map((s) => [s.alias.toLowerCase(), s.canonical]),
@@ -54,17 +58,12 @@ export default function Inventory() {
     return ingredients.find((i) => i.name.toLowerCase() === n.toLowerCase())
   }
 
-  const checkKeywords = async (kws: string[]) => {
+  const matchIngredient = (kws: string[]) => {
     for (const k of kws) {
       const ing = findIngredient(canonical(k))
-      if (ing) {
-        if (window.confirm(`Add 1 of ${ing.name} to inventory?`)) {
-          await createInventory({ ingredient_id: ing.id, quantity: 1 })
-          refresh()
-        }
-        break
-      }
+      if (ing) return ing
     }
+    return null
   }
 
   const refresh = () => {
@@ -77,21 +76,28 @@ export default function Inventory() {
     listSynonyms().then(setSynonyms)
   }, [])
 
-  const onDetected = async (code: string) => {
-    setScanning(false)
+  const runLookup = async (code: string) => {
+    if (!code) return
     const { data, debug: dbg } = await lookupBarcode(code)
     setDebug(
       `GET ${dbg.url}\nStatus: ${dbg.status}\n` +
         `Response: ${JSON.stringify(dbg.body, null, 2)}`,
     )
-    if (data?.name) {
-      setName(data.name)
-      setBrand(data.brand || '')
-      setImage(data.image_url || '')
-    }
+    setResult(data)
+    setName(data?.name || '')
+    setBrand(data?.brand || '')
+    setImage(data?.image_url || '')
     if (data?.keywords) {
-      await checkKeywords(data.keywords)
+      setSuggested(matchIngredient(data.keywords))
+    } else {
+      setSuggested(null)
     }
+  }
+
+  const onDetected = async (code: string) => {
+    setScanning(false)
+    setEan(code)
+    await runLookup(code)
   }
 
   const submit = async () => {
@@ -110,6 +116,13 @@ export default function Inventory() {
     setItems(items.map((i) => (i.id === id ? item : i)))
   }
 
+  const addSuggested = async () => {
+    if (!suggested) return
+    await createInventory({ ingredient_id: suggested.id, quantity: 1 })
+    setSuggested(null)
+    refresh()
+  }
+
   const remove = async (id: number) => {
     await deleteInventory(id)
     setItems(items.filter((i) => i.id !== id))
@@ -118,18 +131,59 @@ export default function Inventory() {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Inventory</h1>
-      {scanning ? (
-        <div>
-          <BarcodeScanner onDetected={onDetected} />
-          <button onClick={() => setScanning(false)} className="mt-2 rounded bg-gray-200 px-2 py-1">
-            Cancel
+
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Barcode Lookup</h2>
+        {scanning ? (
+          <div>
+            <BarcodeScanner onDetected={onDetected} />
+            <button
+              onClick={() => setScanning(false)}
+              className="mt-2 rounded bg-gray-200 px-2 py-1"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button onClick={() => setScanning(true)} className="button-send">
+            Scan Barcode
+          </button>
+        )}
+        <div className="flex gap-2">
+          <input
+            placeholder="Enter barcode"
+            value={ean}
+            onChange={(e) => setEan(e.target.value)}
+            className="border p-1 flex-1"
+          />
+          <button onClick={() => runLookup(ean)} className="button-search">
+            Lookup
           </button>
         </div>
-      ) : (
-        <button onClick={() => setScanning(true)} className="button-send">
-          Scan Barcode
-        </button>
-      )}
+        {result && (
+          <div className="card flex items-center gap-4">
+            {result.image_url && (
+              <img
+                src={result.image_url}
+                alt={result.name || 'product'}
+                className="h-16 w-16 rounded object-cover"
+              />
+            )}
+            <div className="flex-1">
+              {result.name && <p className="font-semibold">{result.name}</p>}
+              {result.brand && (
+                <p className="text-sm text-gray-400">{result.brand}</p>
+              )}
+            </div>
+            {suggested && (
+              <button onClick={addSuggested} className="button-send">
+                Add 1 {suggested.name}
+              </button>
+            )}
+          </div>
+        )}
+      </section>
+
       <div className="space-x-2">
         <input
           placeholder="Name"


### PR DESCRIPTION
## Summary
- improve Inventory page UX
- allow manual barcode lookup alongside scanner
- show barcode results with optional add button

## Testing
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873947f87e88330a04ff9fcbe8cab02