### PR TITLE
Implement cached barcode lookup

### DIFF
--- a/backend/app/api/barcode.py
+++ b/backend/app/api/barcode.py
@@ -1,11 +1,13 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
 from ..services import barcode as barcode_service
+from ..db import session as db_session
 
 router = APIRouter()
 
 @router.get("/{ean}")
-async def lookup_barcode(ean: str):
-    data = await barcode_service.fetch_barcode(ean)
+async def lookup_barcode(ean: str, db: Session = Depends(db_session.get_db)):
+    data = await barcode_service.fetch_barcode(ean, db)
     if not data:
         raise HTTPException(status_code=404, detail="Barcode not found")
     return data

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Text
 from sqlalchemy.orm import declarative_base, relationship
+from datetime import datetime
 
 Base = declarative_base()
 
@@ -78,3 +79,11 @@ class InventoryItem(Base):
     status = Column(String, default="available")
 
     ingredient = relationship("Ingredient")
+
+
+class BarcodeCache(Base):
+    __tablename__ = "barcode_cache"
+
+    ean = Column(String, primary_key=True, index=True)
+    data = Column(Text, nullable=False)
+    fetched_at = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from typing import Optional, List
+from datetime import datetime
 
 class IngredientBase(BaseModel):
     name: str
@@ -99,3 +100,12 @@ class InventoryItemWithIngredient(InventoryItem):
 class Synonym(BaseModel):
     alias: str
     canonical: str
+
+
+class BarcodeCache(BaseModel):
+    ean: str
+    data: str
+    fetched_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/barcode.py
+++ b/backend/app/services/barcode.py
@@ -1,14 +1,28 @@
 import httpx
+import json
+from datetime import datetime, timedelta
 from typing import Optional, Dict
+from sqlalchemy.orm import Session
+
+from ..db import crud
 
 # Simple in-memory cache
 _cache: Dict[str, Dict] = {}
 
 API_URL = "https://world.openfoodfacts.org/api/v0/product"
 
-async def fetch_barcode(ean: str) -> Optional[Dict]:
+async def fetch_barcode(ean: str, db: Session) -> Optional[Dict]:
     if ean in _cache:
         return _cache[ean]
+
+    entry = crud.get_barcode_cache(db, ean)
+    if entry:
+        if datetime.utcnow() - entry.fetched_at < timedelta(days=30):
+            data = json.loads(entry.data)
+            result = {"name": data.get("product", {}).get("product_name")}
+            _cache[ean] = result
+            return result
+
     url = f"{API_URL}/{ean}.json"
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, timeout=10)
@@ -17,6 +31,7 @@ async def fetch_barcode(ean: str) -> Optional[Dict]:
         data = resp.json()
         if data.get("status") != 1:
             return None
-        result = {"name": data.get("product", {}).get("product_name")}
-        _cache[ean] = result
-        return result
+    crud.upsert_barcode_cache(db, ean, data)
+    result = {"name": data.get("product", {}).get("product_name")}
+    _cache[ean] = result
+    return result

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -157,7 +157,7 @@ async def test_inventory_patch(async_client):
 
 @pytest.mark.asyncio
 async def test_barcode_lookup(monkeypatch, async_client):
-    async def fake_lookup(ean: str):
+    async def fake_lookup(ean: str, db):
         return {"name": "Test"}
 
     monkeypatch.setattr("backend.app.services.barcode.fetch_barcode", fake_lookup)


### PR DESCRIPTION
## Summary
- cache OpenFoodFacts API responses in database
- refresh barcode data after 1 month
- adjust API endpoint to provide DB session
- update tests for new service signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68739b4674bc8330824962aeed12bf0c