### PR TITLE
Implement persistent barcode caching

### DIFF
--- a/backend/app/api/barcode.py
+++ b/backend/app/api/barcode.py
@@ -1,11 +1,14 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+
 from ..services import barcode as barcode_service
+from ..db import session as db_session
 
 router = APIRouter()
 
 @router.get("/{ean}")
-async def lookup_barcode(ean: str):
-    data = await barcode_service.fetch_barcode(ean)
+async def lookup_barcode(ean: str, db: Session = Depends(db_session.get_db)):
+    data, from_cache = await barcode_service.fetch_barcode(ean, db)
     if not data:
         raise HTTPException(status_code=404, detail="Barcode not found")
-    return data
+    return {"data": data, "from_cache": from_cache}

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -245,3 +245,25 @@ def search_local_recipes(
         )
         for r, a, m in results
     ]
+
+
+# Barcode cache CRUD
+def get_barcode_cache(db: Session, ean: str):
+    return db.query(models.BarcodeCache).filter(models.BarcodeCache.ean == ean).first()
+
+
+def store_barcode_cache(db: Session, ean: str, data: dict):
+    import json
+    from datetime import datetime
+
+    entry = get_barcode_cache(db, ean)
+    serialized = json.dumps(data)
+    ts = int(datetime.utcnow().timestamp())
+    if entry:
+        entry.json = serialized
+        entry.timestamp = ts
+    else:
+        entry = models.BarcodeCache(ean=ean, json=serialized, timestamp=ts)
+        db.add(entry)
+    db.commit()
+    return entry

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Column, Integer, String, ForeignKey, Float, Table
+from sqlalchemy import Column, Integer, String, ForeignKey, Float, Table, Text
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -172,3 +172,11 @@ class InventoryItem(Base):
     status = Column(String, default="available")
 
     ingredient = relationship("Ingredient")
+
+
+class BarcodeCache(Base):
+    __tablename__ = "barcode_cache"
+
+    ean = Column(String, primary_key=True, index=True)
+    timestamp = Column(Integer, nullable=False)
+    json = Column(Text, nullable=False)

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -123,3 +123,12 @@ class InventoryItemWithIngredient(InventoryItem):
 class Synonym(BaseModel):
     alias: str
     canonical: str
+
+
+class BarcodeCache(BaseModel):
+    ean: str
+    timestamp: int
+    json: str
+
+    class Config:
+        orm_mode = True

--- a/backend/app/services/barcode.py
+++ b/backend/app/services/barcode.py
@@ -1,29 +1,41 @@
 import httpx
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
+from sqlalchemy.orm import Session
+
+from ..db import crud
+import json
 
 # Simple in-memory cache
 _cache: Dict[str, Dict] = {}
 
 API_URL = "https://world.openfoodfacts.org/api/v0/product"
 
-async def fetch_barcode(ean: str) -> Optional[Dict]:
+async def fetch_barcode(ean: str, db: Session) -> Tuple[Optional[Dict], bool]:
+    """Fetch barcode information, returning data and cache flag."""
     if ean in _cache:
-        return _cache[ean]
+        return _cache[ean], True
+
+    entry = crud.get_barcode_cache(db, ean)
+    if entry:
+        data = json.loads(entry.json)
+        _cache[ean] = data
+        return data, True
+
     url = f"{API_URL}/{ean}.json"
-    print(url)
     async with httpx.AsyncClient() as client:
         resp = await client.get(url, timeout=10)
-        if resp.status_code != 200:
-            return None
-        data = resp.json()
-        if data.get("status") != 1:
-            return None
-        product = data.get("product", {})
-        result = {
-            "name": product.get("product_name"),
-            "brand": product.get("brands"),
-            "image_url": product.get("image_front_url"),
-            "keywords": product.get("_keywords", []),
-        }
-        _cache[ean] = result
-        return result
+    if resp.status_code != 200:
+        return None, False
+    data = resp.json()
+    if data.get("status") != 1:
+        return None, False
+    product = data.get("product", {})
+    result = {
+        "name": product.get("product_name"),
+        "brand": product.get("brands"),
+        "image_url": product.get("image_front_url"),
+        "keywords": product.get("_keywords", []),
+    }
+    crud.store_barcode_cache(db, ean, data)
+    _cache[ean] = result
+    return result, False

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -162,18 +162,23 @@ async def test_inventory_patch(async_client):
 
 @pytest.mark.asyncio
 async def test_barcode_lookup(monkeypatch, async_client):
-    async def fake_lookup(ean: str):
-        return {
-            "name": "Test",
-            "brand": "Foo",
-            "image_url": "http://img",
-            "keywords": ["gin", "liquor"],
-        }
+    async def fake_lookup(ean: str, db):
+        return (
+            {
+                "name": "Test",
+                "brand": "Foo",
+                "image_url": "http://img",
+                "keywords": ["gin", "liquor"],
+            },
+            False,
+        )
 
     monkeypatch.setattr("backend.app.services.barcode.fetch_barcode", fake_lookup)
     resp = await async_client.get("/barcode/123456")
     assert resp.status_code == 200
-    data = resp.json()
+    body = resp.json()
+    data = body["data"]
+    assert body["from_cache"] is False
     assert data["name"] == "Test"
     assert data["brand"] == "Foo"
     assert data["image_url"] == "http://img"


### PR DESCRIPTION
## Summary
- add `BarcodeCache` table with barcode, timestamp and raw JSON
- persist barcode API data with CRUD helpers
- modify barcode service to use DB-backed cache and indicate cache hits
- expose cache status in barcode API endpoint
- adjust tests for new behavior

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873bd649a248330b2e02fa9ff42c4c9