### PR TITLE
Improve inventory updates and debug view

### DIFF
--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -144,6 +144,12 @@ def get_inventory_by_ingredient(db: Session, ingredient_id: int):
 
 
 def create_inventory_item(db: Session, item: schemas.InventoryItemCreate):
+    existing = get_inventory_by_ingredient(db, item.ingredient_id)
+    if existing:
+        existing.quantity += item.quantity
+        db.commit()
+        db.refresh(existing)
+        return existing
     db_obj = models.InventoryItem(**item.model_dump())
     db.add(db_obj)
     db.commit()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -197,6 +197,25 @@ async def test_inventory_create_delete(async_client):
 
 
 @pytest.mark.asyncio
+async def test_inventory_create_increment(async_client):
+    resp = await async_client.post("/ingredients/", json={"name": "Rum"})
+    ing_id = resp.json()["id"]
+    resp = await async_client.post(
+        "/inventory/", json={"ingredient_id": ing_id, "quantity": 1}
+    )
+    assert resp.status_code == 201
+    resp = await async_client.post(
+        "/inventory/", json={"ingredient_id": ing_id, "quantity": 1}
+    )
+    assert resp.status_code == 201
+    assert resp.json()["quantity"] == 2
+    resp = await async_client.get("/inventory/")
+    items = [i for i in resp.json() if i["ingredient"]["id"] == ing_id]
+    assert len(items) == 1
+    assert items[0]["quantity"] == 2
+
+
+@pytest.mark.asyncio
 async def test_recipe_import_adds_inventory(monkeypatch, async_client):
     async def fake_fetch(name: str):
         return {


### PR DESCRIPTION
## Summary
- prevent duplicate inventory entries by updating quantity when an item exists
- add integration test for inventory increments
- allow showing/hiding fetch debug info in Inventory page
- increment existing items when adding scanned suggestions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c95517a4833090428489176a516f