### PR TITLE
Add reset shopping list endpoint and UI buttons

### DIFF
--- a/backend/app/api/shopping_list.py
+++ b/backend/app/api/shopping_list.py
@@ -17,3 +17,9 @@ def add_from_recipe(recipe_id: int, db: Session = Depends(session.get_db)):
     if items is None:
         raise HTTPException(status_code=404, detail="Recipe not found")
     return items
+
+
+@router.delete("/", status_code=204)
+def clear_list(db: Session = Depends(session.get_db)):
+    crud.clear_shopping_list(db)
+    return None

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -327,3 +327,8 @@ def add_missing_ingredients_to_shopping_list(db: Session, recipe_id: int):
     missing = recipe_missing_ingredients(db, recipe)
     items = [add_to_shopping_list(db, ing, 1) for ing in missing]
     return items
+
+
+def clear_shopping_list(db: Session):
+    db.query(models.ShoppingListItem).delete()
+    db.commit()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -459,3 +459,37 @@ async def test_shopping_list_from_recipe(monkeypatch, async_client):
     assert len(items) == 1
     assert items[0]["ingredient"]["name"] == "Gin"
 
+
+@pytest.mark.asyncio
+async def test_clear_shopping_list(monkeypatch, async_client):
+    async def fake_fetch(name: str):
+        return {
+            "name": "Gin Drink",
+            "alcoholic": "Alcoholic",
+            "instructions": "Mix",
+            "thumb": None,
+            "tags": [],
+            "categories": [],
+            "ibas": [],
+            "ingredients": [
+                {"name": "Gin", "measure": "1 oz"},
+            ],
+        }
+
+    monkeypatch.setattr(
+        "backend.app.services.cocktaildb.fetch_recipe_details", fake_fetch
+    )
+    monkeypatch.setattr("backend.app.api.recipes.fetch_recipe_details", fake_fetch)
+
+    resp = await async_client.post("/recipes/", json={"name": "gin drink"})
+    recipe_id = resp.json()["id"]
+
+    await async_client.post(f"/shopping-list/from-recipe/{recipe_id}")
+
+    resp = await async_client.delete("/shopping-list/")
+    assert resp.status_code == 204
+
+    resp = await async_client.get("/shopping-list/")
+    assert resp.status_code == 200
+    assert resp.json() == []
+

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -199,6 +199,10 @@ export async function listShoppingList() {
   return fetchJson<ShoppingListItem[]>(`${API_BASE}/shopping-list/`);
 }
 
+export async function clearShoppingList() {
+  return fetchJson<void>(`${API_BASE}/shopping-list/`, { method: "DELETE" });
+}
+
 export async function addMissingFromRecipe(recipe_id: number) {
   return fetchJson<ShoppingListItem[]>(
     `${API_BASE}/shopping-list/from-recipe/${recipe_id}`,

--- a/frontend/src/pages/ShoppingList.tsx
+++ b/frontend/src/pages/ShoppingList.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from 'react';
-import { listShoppingList, type ShoppingListItem } from '../api';
+import {
+  listShoppingList,
+  clearShoppingList,
+  type ShoppingListItem,
+} from '../api';
 
 export default function ShoppingList() {
   const [items, setItems] = useState<ShoppingListItem[]>([]);
@@ -10,16 +14,47 @@ export default function ShoppingList() {
     });
   }, []);
 
+  const reset = async () => {
+    const { debug } = await clearShoppingList();
+    if (debug) console.debug(debug);
+    setItems([]);
+  };
+
+  const download = () => {
+    const lines = items.map(
+      (it) => `${it.quantity} x ${it.ingredient?.name || it.ingredient_id}`,
+    );
+    const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'shopping_list.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Shopping List</h1>
-      <ul className="list-disc pl-5">
-        {items.map((it) => (
-          <li key={it.id}>
-            {it.quantity} x {it.ingredient?.name || it.ingredient_id}
-          </li>
-        ))}
-      </ul>
+    <div className="space-y-6">
+      <h1 className="font-display text-3xl font-semibold">Shopping List</h1>
+      <div className="flex gap-4">
+        <button onClick={download} className="button-search">
+          Download
+        </button>
+        <button onClick={reset} className="button-send">
+          Reset
+        </button>
+      </div>
+      <div className="card p-0">
+        <ul className="divide-y divide-[var(--border)]">
+          {items.map((it) => (
+            <li key={it.id} className="flex items-center justify-between p-4">
+              <span>
+                {it.quantity} x {it.ingredient?.name || it.ingredient_id}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -109,6 +109,8 @@ paths:
   /shopping-list:
     get:
       summary: List shopping list items
+    delete:
+      summary: Clear shopping list
     post:
       summary: Add missing ingredients from recipe
       parameters:


### PR DESCRIPTION
## Summary
- support clearing the shopping list via `DELETE /shopping-list/`
- expose new API helper `clearShoppingList`
- redesign Shopping List page with download/reset buttons
- document endpoint in `openapi_paths.yaml`
- test clearing the shopping list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a355b8208330b41f4402c5bb473a