### PR TITLE
Fix barcode lookup result handling

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -101,6 +101,7 @@ export interface BarcodeDebug {
 
 export interface BarcodeLookup {
   data: BarcodeResult | null
+  from_cache: boolean
   debug: BarcodeDebug
 }
 
@@ -109,12 +110,13 @@ export async function lookupBarcode(ean: string): Promise<BarcodeLookup> {
   const res = await fetch(url)
   const body = await res.json().catch(() => null)
   return {
-    data: res.ok ? (body as BarcodeResult) : null,
+    data: res.ok ? (body?.data as BarcodeResult) : null,
+    from_cache: Boolean(body?.from_cache),
     debug: {
       url,
       status: res.status,
-      body
-    }
+      body,
+    },
   }
 }
 

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -82,7 +82,7 @@ export default function Inventory() {
     if (!code) return
     const { data, debug: dbg } = await lookupBarcode(code)
     addDebug(dbg)
-    setResult(data?.data || null)
+    setResult(data || null)
     setName(data?.name || '')
     if (data?.keywords) {
       setSuggested(matchIngredient(data.keywords))


### PR DESCRIPTION
## Summary
- parse API response correctly in `lookupBarcode`
- update inventory page to use new return type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b70ae0888330ba0725b2a653e879