### PR TITLE
Add unit synonyms API and enhance debug log toggle

### DIFF
--- a/backend/app/api/unit_synonyms.py
+++ b/backend/app/api/unit_synonyms.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, HTTPException
+
+from ..services import unit_synonyms
+from ..db import schemas
+
+router = APIRouter()
+
+@router.get('/', response_model=list[schemas.Synonym])
+def list_synonyms():
+    return unit_synonyms.list_synonyms()
+
+@router.post('/', response_model=schemas.Synonym, status_code=201)
+def create_synonym(s: schemas.Synonym):
+    if not s.alias or not s.canonical:
+        raise HTTPException(status_code=400, detail='Invalid data')
+    return unit_synonyms.add_synonym(s.alias, s.canonical)
+
+@router.delete('/{alias}', status_code=204)
+def delete_synonym(alias: str):
+    unit_synonyms.delete_synonym(alias)
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,15 @@ from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 import logging
 
-from .api import ingredients, recipes, inventory, barcode, synonyms, shopping_list
+from .api import (
+    ingredients,
+    recipes,
+    inventory,
+    barcode,
+    synonyms,
+    unit_synonyms,
+    shopping_list,
+)
 
 app = FastAPI(title="Bar Management")
 
@@ -41,5 +49,6 @@ app.include_router(recipes.router, prefix="/recipes")
 app.include_router(inventory.router, prefix="/inventory")
 app.include_router(barcode.router, prefix="/barcode")
 app.include_router(synonyms.router, prefix="/synonyms")
+app.include_router(unit_synonyms.router, prefix="/unit-synonyms")
 app.include_router(shopping_list.router, prefix="/shopping-list")
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -335,6 +335,32 @@ async def test_synonym_crud(async_client):
 
 
 @pytest.mark.asyncio
+async def test_unit_synonym_crud(async_client):
+    resp = await async_client.get("/unit-synonyms/")
+    assert resp.status_code == 200
+    aliases = [s["alias"] for s in resp.json()]
+    assert "testunit" not in aliases
+
+    resp = await async_client.post(
+        "/unit-synonyms/",
+        json={"alias": "testunit", "canonical": "tu"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["canonical"] == "tu"
+
+    resp = await async_client.get("/unit-synonyms/")
+    aliases = [s["alias"] for s in resp.json()]
+    assert "testunit" in aliases
+
+    resp = await async_client.delete("/unit-synonyms/testunit")
+    assert resp.status_code == 204
+
+    resp = await async_client.get("/unit-synonyms/")
+    aliases = [s["alias"] for s in resp.json()]
+    assert "testunit" not in aliases
+
+
+@pytest.mark.asyncio
 async def test_unit_synonym_handled(monkeypatch, async_client):
     async def fake_fetch(name: str):
         return {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -190,6 +190,25 @@ export async function deleteSynonym(alias: string) {
   });
 }
 
+export async function listUnitSynonyms() {
+  return fetchJson<Synonym[]>(`${API_BASE}/unit-synonyms/`);
+}
+
+export async function addUnitSynonym(alias: string, canonical: string) {
+  return fetchJson<Synonym>(`${API_BASE}/unit-synonyms/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ alias, canonical }),
+  });
+}
+
+export async function deleteUnitSynonym(alias: string) {
+  return fetchJson<void>(
+    `${API_BASE}/unit-synonyms/${encodeURIComponent(alias)}`,
+    { method: "DELETE" },
+  );
+}
+
 export interface ShoppingListItem {
   id: number;
   ingredient_id: number;

--- a/frontend/src/pages/Synonyms.tsx
+++ b/frontend/src/pages/Synonyms.tsx
@@ -3,6 +3,9 @@ import {
   listSynonyms,
   addSynonym,
   deleteSynonym,
+  listUnitSynonyms,
+  addUnitSynonym,
+  deleteUnitSynonym,
   type FetchDebug,
   type Synonym,
 } from '../api';
@@ -10,9 +13,13 @@ import {
 
 export default function Synonyms() {
   const [synonyms, setSynonyms] = useState<Synonym[]>([]);
+  const [unitSynonyms, setUnitSynonyms] = useState<Synonym[]>([]);
   const [alias, setAlias] = useState('');
   const [canonical, setCanonical] = useState('');
+  const [unitAlias, setUnitAlias] = useState('');
+  const [unitCanonical, setUnitCanonical] = useState('');
   const [debugLog, setDebugLog] = useState<string[]>([]);
+  const [showDebug, setShowDebug] = useState(false);
 
   const formatDebug = (dbg: FetchDebug) =>
     `GET ${dbg.url}\nStatus: ${dbg.status}\n` +
@@ -25,6 +32,10 @@ export default function Synonyms() {
     listSynonyms().then(({ data, debug }) => {
       if (debug) addDebug(debug);
       if (data) setSynonyms(data);
+    });
+    listUnitSynonyms().then(({ data, debug }) => {
+      if (debug) addDebug(debug);
+      if (data) setUnitSynonyms(data);
     });
   };
 
@@ -41,15 +52,36 @@ export default function Synonyms() {
     refresh();
   };
 
+  const submitUnit = async () => {
+    if (!unitAlias || !unitCanonical) return;
+    const { debug } = await addUnitSynonym(unitAlias, unitCanonical);
+    if (debug) addDebug(debug);
+    setUnitAlias('');
+    setUnitCanonical('');
+    refresh();
+  };
+
   const remove = async (a: string) => {
     const { debug } = await deleteSynonym(a);
     if (debug) addDebug(debug);
     setSynonyms(synonyms.filter((s) => s.alias !== a));
   };
 
+  const removeUnit = async (a: string) => {
+    const { debug } = await deleteUnitSynonym(a);
+    if (debug) addDebug(debug);
+    setUnitSynonyms(unitSynonyms.filter((s) => s.alias !== a));
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">Synonyms</h1>
+      <button
+        onClick={() => setShowDebug((v) => !v)}
+        className="rounded bg-gray-200 px-2 py-1"
+      >
+        {showDebug ? 'Hide Debug' : 'Show Debug'}
+      </button>
       <div className="space-x-2">
         <input
           placeholder="Alias"
@@ -89,7 +121,48 @@ export default function Synonyms() {
           ))}
         </tbody>
       </table>
-      {debugLog.length > 0 && (
+
+      <h2 className="text-xl font-bold">Unit Synonyms</h2>
+      <div className="space-x-2">
+        <input
+          placeholder="Alias"
+          value={unitAlias}
+          onChange={(e) => setUnitAlias(e.target.value)}
+          className="border p-1"
+        />
+        <input
+          placeholder="Canonical"
+          value={unitCanonical}
+          onChange={(e) => setUnitCanonical(e.target.value)}
+          className="border p-1"
+        />
+        <button onClick={submitUnit} className="rounded bg-blue-500 px-2 py-1 text-white">
+          Add
+        </button>
+      </div>
+      <table className="min-w-full border text-left">
+        <thead>
+          <tr>
+            <th className="px-2">Alias</th>
+            <th className="px-2">Canonical</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {unitSynonyms.map((s) => (
+            <tr key={s.alias} className="border-t">
+              <td className="px-2 py-1">{s.alias}</td>
+              <td className="px-2 py-1">{s.canonical}</td>
+              <td className="px-2 py-1">
+                <button onClick={() => removeUnit(s.alias)} className="text-red-600">
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {showDebug && debugLog.length > 0 && (
         <pre className="whitespace-pre-wrap bg-gray-100 p-2 text-xs">
           {debugLog.join('\n\n')}
         </pre>

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -86,9 +86,17 @@ paths:
       summary: List synonyms
     post:
       summary: Create synonym
+  /unit-synonyms:
+    get:
+      summary: List unit synonyms
+    post:
+      summary: Create unit synonym
   /synonyms/{alias}:
     delete:
       summary: Delete synonym
+  /unit-synonyms/{alias}:
+    delete:
+      summary: Delete unit synonym
     patch:
       summary: Update inventory item
       parameters:


### PR DESCRIPTION
## Summary
- add REST endpoints for measurement unit synonyms
- update openapi docs
- expose unit-synonym API functions in the frontend
- extend Synonyms page with a debug toggle and unit synonym table
- test unit-synonym CRUD

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c3699aac833095bd76169a68af3a