### PR TITLE
Show inventory per ingredient

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from ..db import crud, schemas, session
@@ -40,12 +40,10 @@ def list_recipes(skip: int = 0, limit: int = 100, db: Session = Depends(session.
     return crud.list_recipes(db, skip=skip, limit=limit)
 
 
-@router.get("/{recipe_id}", response_model=schemas.Recipe)
+@router.get("/{recipe_id}", response_model=schemas.RecipeDetail)
 def get_recipe(recipe_id: int, db: Session = Depends(session.get_db)):
-    recipe = crud.get_recipe(db, recipe_id)
+    recipe = crud.get_recipe_with_inventory(db, recipe_id)
     if not recipe:
-        from fastapi import HTTPException
-
         raise HTTPException(status_code=404, detail="Recipe not found")
     return recipe
 

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -97,6 +97,18 @@ class RecipeWithInventory(Recipe):
     class Config:
         orm_mode = True
 
+
+class RecipeIngredientWithInventory(RecipeIngredient):
+    """Recipe ingredient including current inventory quantity."""
+    inventory_item_id: int | None = None
+    inventory_quantity: int = 0
+
+
+class RecipeDetail(Recipe):
+    """Full recipe data with inventory info for each ingredient."""
+    ingredients: List[RecipeIngredientWithInventory] = []
+
+
 class InventoryItemBase(BaseModel):
     ingredient_id: int
     quantity: int

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -103,12 +103,17 @@ async def test_get_recipe(monkeypatch, async_client):
     monkeypatch.setattr(
         "backend.app.services.cocktaildb.fetch_recipe_details", fake_fetch
     )
+    monkeypatch.setattr("backend.app.api.recipes.fetch_recipe_details", fake_fetch)
     resp = await async_client.post("/recipes/", json={"name": "mojito"})
     recipe_id = resp.json()["id"]
 
     resp = await async_client.get(f"/recipes/{recipe_id}")
     assert resp.status_code == 200
-    assert resp.json()["name"] == "Mojito"
+    data = resp.json()
+    assert data["name"] == "Mojito"
+    ing = next(i for i in data["ingredients"] if i["name"] == "Rum")
+    assert ing["inventory_quantity"] == 0
+    assert ing["inventory_item_id"] is not None
 
 
 @pytest.mark.asyncio

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -65,7 +65,7 @@ paths:
       summary: Add recipe from CocktailDB
   /recipes/{recipe_id}:
     get:
-      summary: Get recipe
+      summary: Get recipe with inventory
       parameters:
         - in: path
           name: recipe_id


### PR DESCRIPTION
## Summary
- include inventory quantity per ingredient in recipe detail endpoint
- expose the data through a new schema and CRUD helper
- adjust openapi spec and API route
- test recipe detail with inventory info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c98264e88330b0e6899caae5919c