### PR TITLE
Show recipe inventory details

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -36,6 +36,22 @@ export interface InventoryItem {
   ingredient?: Ingredient;
 }
 
+export interface RecipeIngredient {
+  id: number;
+  name: string;
+  measure?: string | null;
+  inventory_item_id?: number | null;
+  inventory_quantity: number;
+}
+
+export interface RecipeDetail {
+  id: number;
+  name: string;
+  instructions?: string | null;
+  thumb?: string | null;
+  ingredients: RecipeIngredient[];
+}
+
 export async function healthCheck() {
   const res = await fetch(`${API_BASE}/healthz`);
   if (!res.ok) {
@@ -155,7 +171,7 @@ export async function findRecipes(options: FindRecipesOptions = {}) {
   return res.json();
 }
 
-export async function getRecipe(id: number) {
+export async function getRecipe(id: number): Promise<RecipeDetail> {
   const res = await fetch(`${API_BASE}/recipes/${id}`);
   if (!res.ok) {
     throw new Error("Recipe not found");

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -1,24 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { getRecipe, addMissingFromRecipe } from '../api';
+import {
+  getRecipe,
+  addMissingFromRecipe,
+  type RecipeDetail,
+} from '../api';
 
-interface Ingredient {
-  id: number;
-  name: string;
-  measure?: string | null;
-}
-
-interface Recipe {
-  id: number;
-  name: string;
-  instructions?: string | null;
-  thumb?: string | null;
-  ingredients?: Ingredient[];
-}
 
 export default function RecipeDetail() {
   const { id } = useParams<{ id: string }>();
-  const [recipe, setRecipe] = useState<Recipe | null>(null);
+  const [recipe, setRecipe] = useState<RecipeDetail | null>(null);
   const [added, setAdded] = useState(false);
 
   useEffect(() => {
@@ -59,6 +50,9 @@ export default function RecipeDetail() {
               <li key={ing.id}>
                 {ing.measure ? `${ing.measure} ` : ''}
                 {ing.name}
+                <span className="text-sm text-[var(--text-secondary)]">
+                  {` – ${ing.inventory_quantity} in stock`}
+                </span>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- track inventory info in frontend Recipe APIs
- show quantity in stock for recipe ingredients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d3b1b4908330b68c13113d3e7397