### PR TITLE
Add synonym aggregation

### DIFF
--- a/backend/app/api/inventory.py
+++ b/backend/app/api/inventory.py
@@ -11,6 +11,13 @@ def list_items(skip: int = 0, limit: int = 100, db: Session = Depends(session.ge
     return crud.list_inventory_items(db, skip=skip, limit=limit)
 
 
+@router.post("/aggregate-synonyms", status_code=200)
+def aggregate_synonyms(db: Session = Depends(session.get_db)):
+    """Aggregate inventory items using current synonyms."""
+    crud.aggregate_inventory_by_synonyms(db)
+    return {"status": "ok"}
+
+
 @router.post("/", response_model=schemas.InventoryItem, status_code=201)
 def create_item(item: schemas.InventoryItemCreate, db: Session = Depends(session.get_db)):
     return crud.create_inventory_item(db, item)

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -225,6 +225,12 @@ export async function deleteUnitSynonym(alias: string) {
   );
 }
 
+export async function aggregateInventorySynonyms() {
+  return fetchJson<void>(`${API_BASE}/inventory/aggregate-synonyms`, {
+    method: "POST",
+  });
+}
+
 export interface ShoppingListItem {
   id: number;
   ingredient_id: number;

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -6,6 +6,7 @@ import {
   createInventory,
   updateInventory,
   deleteInventory,
+  aggregateInventorySynonyms,
   lookupBarcode,
   listIngredients,
   listSynonyms,
@@ -213,6 +214,16 @@ export default function Inventory() {
         />
         <button onClick={submit} className="button-search">
           Add
+        </button>
+        <button
+          onClick={async () => {
+            const { debug } = await aggregateInventorySynonyms();
+            if (debug) addDebug(debug);
+            refresh();
+          }}
+          className="button-send"
+        >
+          Aggregate Synonyms
         </button>
       </div>
       <table className="min-w-full border border-[var(--border)] text-left">

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -114,6 +114,9 @@ paths:
           required: true
           schema:
             type: string
+  /inventory/aggregate-synonyms:
+    post:
+      summary: Aggregate inventory items using current synonyms
   /shopping-list:
     get:
       summary: List shopping list items


### PR DESCRIPTION
## Summary
- aggregate inventory items when new synonyms are added
- expose POST `/inventory/aggregate-synonyms` endpoint
- hook up React client for aggregation action
- document the new route
- test synonym aggregation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750c07b2a0833085728e0709b6ed47