### PR TITLE
Add synonym import

### DIFF
--- a/backend/app/api/synonyms.py
+++ b/backend/app/api/synonyms.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException
+from fastapi import Body
 
 from ..services import synonyms
 from ..db import schemas
@@ -22,3 +23,11 @@ def create_synonym(s: schemas.Synonym):
 def delete_synonym(alias: str):
     synonyms.delete_synonym(alias)
     return None
+
+
+@router.post("/import", status_code=201)
+def import_synonym_data(data: dict[str, str] = Body(...)):
+    if not data:
+        raise HTTPException(status_code=400, detail="No data provided")
+    synonyms.import_synonyms(data)
+    return {"imported": len(data)}

--- a/backend/app/api/unit_synonyms.py
+++ b/backend/app/api/unit_synonyms.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException
+from fastapi import Body
 
 from ..services import unit_synonyms
 from ..db import schemas
@@ -19,3 +20,11 @@ def create_synonym(s: schemas.Synonym):
 def delete_synonym(alias: str):
     unit_synonyms.delete_synonym(alias)
     return None
+
+
+@router.post('/import', status_code=201)
+def import_unit_synonym_data(data: dict[str, str] = Body(...)):
+    if not data:
+        raise HTTPException(status_code=400, detail='No data provided')
+    unit_synonyms.import_synonyms(data)
+    return {"imported": len(data)}

--- a/backend/app/services/synonyms.py
+++ b/backend/app/services/synonyms.py
@@ -44,6 +44,12 @@ def delete_synonym(alias: str) -> None:
     _save()
 
 
+def import_synonyms(mapping: dict[str, str]) -> None:
+    """Import multiple synonym mappings."""
+    for alias, canonical in mapping.items():
+        ALIASES[alias.strip().lower()] = canonical.strip().title()
+    _save()
+
 def canonical_name(name: str) -> str:
     """Return a normalized ingredient name using known aliases."""
     key = name.strip().lower()

--- a/backend/app/services/unit_synonyms.py
+++ b/backend/app/services/unit_synonyms.py
@@ -47,3 +47,10 @@ def delete_synonym(alias: str) -> None:
 
 def list_synonyms() -> list[dict[str, str]]:
     return [{"alias": a, "canonical": c} for a, c in ALIASES.items()]
+
+
+def import_synonyms(mapping: dict[str, str]) -> None:
+    """Import multiple unit synonyms."""
+    for alias, canonical in mapping.items():
+        ALIASES[alias.strip().lower()] = canonical.strip().lower()
+    _save()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -340,6 +340,18 @@ async def test_synonym_crud(async_client):
 
 
 @pytest.mark.asyncio
+async def test_synonym_import(async_client):
+    data = {"tester": "Test"}
+    resp = await async_client.post("/synonyms/import", json=data)
+    assert resp.status_code == 201
+    resp = await async_client.get("/synonyms/")
+    aliases = [s["alias"] for s in resp.json()]
+    assert "tester" in aliases
+    await async_client.delete("/synonyms/tester")
+
+
+
+@pytest.mark.asyncio
 async def test_unit_synonym_crud(async_client):
     resp = await async_client.get("/unit-synonyms/")
     assert resp.status_code == 200
@@ -363,6 +375,17 @@ async def test_unit_synonym_crud(async_client):
     resp = await async_client.get("/unit-synonyms/")
     aliases = [s["alias"] for s in resp.json()]
     assert "testunit" not in aliases
+
+
+@pytest.mark.asyncio
+async def test_unit_synonym_import(async_client):
+    data = {"unittest": "ut"}
+    resp = await async_client.post("/unit-synonyms/import", json=data)
+    assert resp.status_code == 201
+    resp = await async_client.get("/unit-synonyms/")
+    aliases = [s["alias"] for s in resp.json()]
+    assert "unittest" in aliases
+    await async_client.delete("/unit-synonyms/unittest")
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -206,6 +206,14 @@ export async function deleteSynonym(alias: string) {
   });
 }
 
+export async function importSynonyms(data: Record<string, string>) {
+  return fetchJson<void>(`${API_BASE}/synonyms/import`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
 export async function listUnitSynonyms() {
   return fetchJson<Synonym[]>(`${API_BASE}/unit-synonyms/`);
 }
@@ -223,6 +231,14 @@ export async function deleteUnitSynonym(alias: string) {
     `${API_BASE}/unit-synonyms/${encodeURIComponent(alias)}`,
     { method: "DELETE" },
   );
+}
+
+export async function importUnitSynonyms(data: Record<string, string>) {
+  return fetchJson<void>(`${API_BASE}/unit-synonyms/import`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
 }
 
 export async function aggregateInventorySynonyms() {

--- a/frontend/src/pages/Synonyms.tsx
+++ b/frontend/src/pages/Synonyms.tsx
@@ -3,9 +3,11 @@ import {
   listSynonyms,
   addSynonym,
   deleteSynonym,
+  importSynonyms,
   listUnitSynonyms,
   addUnitSynonym,
   deleteUnitSynonym,
+  importUnitSynonyms,
   type FetchDebug,
   type Synonym,
 } from '../api';
@@ -20,6 +22,10 @@ export default function Synonyms() {
   const [unitCanonical, setUnitCanonical] = useState('');
   const [debugLog, setDebugLog] = useState<string[]>([]);
   const [showDebug, setShowDebug] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [importText, setImportText] = useState('');
+  const [showUnitImport, setShowUnitImport] = useState(false);
+  const [importUnitText, setImportUnitText] = useState('');
 
   const formatDebug = (dbg: FetchDebug) =>
     `GET ${dbg.url}\nStatus: ${dbg.status}\n` +
@@ -73,6 +79,37 @@ export default function Synonyms() {
     setUnitSynonyms(unitSynonyms.filter((s) => s.alias !== a));
   };
 
+  const submitImport = async () => {
+    try {
+      const data = JSON.parse(importText);
+      const { debug } = await importSynonyms(data);
+      if (debug) addDebug(debug);
+      setImportText('');
+      setShowImport(false);
+      refresh();
+    } catch {
+      alert('Invalid JSON');
+    }
+  };
+
+  const submitUnitImport = async () => {
+    try {
+      const data = JSON.parse(importUnitText);
+      const { debug } = await importUnitSynonyms(data);
+      if (debug) addDebug(debug);
+      setImportUnitText('');
+      setShowUnitImport(false);
+      refresh();
+    } catch {
+      alert('Invalid JSON');
+    }
+  };
+
+  const readFile = (e: React.ChangeEvent<HTMLInputElement>, setter: (v: string) => void) => {
+    const file = e.target.files?.[0];
+    if (file) file.text().then(setter);
+  };
+
   return (
     <div className="space-y-4">
       <h1 className="text-3xl font-bold font-display">Synonyms</h1>
@@ -89,10 +126,32 @@ export default function Synonyms() {
           onChange={(e) => setCanonical(e.target.value)}
           className="border border-[var(--border)] p-1"
         />
-        <button onClick={submit} className="button-send">
-          Add
+        <button onClick={submit} className="button-send">Add</button>
+        <button
+          onClick={() => setShowImport(!showImport)}
+          className="button-search"
+        >
+          Import
         </button>
       </div>
+      {showImport && (
+        <div className="space-y-2 mt-2">
+          <textarea
+            placeholder="{\"alias\": \"Canonical\"}"
+            value={importText}
+            onChange={(e) => setImportText(e.target.value)}
+            className="border border-[var(--border)] p-1 w-full h-24"
+          />
+          <input
+            type="file"
+            accept="application/json"
+            onChange={(e) => readFile(e, setImportText)}
+          />
+          <button onClick={submitImport} className="button-send">
+            Import JSON
+          </button>
+        </div>
+      )}
       <table className="min-w-full border border-[var(--border)] text-left">
         <thead>
           <tr>
@@ -130,10 +189,32 @@ export default function Synonyms() {
           onChange={(e) => setUnitCanonical(e.target.value)}
           className="border border-[var(--border)] p-1"
         />
-        <button onClick={submitUnit} className="button-send">
-          Add
+        <button onClick={submitUnit} className="button-send">Add</button>
+        <button
+          onClick={() => setShowUnitImport(!showUnitImport)}
+          className="button-search"
+        >
+          Import
         </button>
       </div>
+      {showUnitImport && (
+        <div className="space-y-2 mt-2">
+          <textarea
+            placeholder="{\"alias\": \"canonical\"}"
+            value={importUnitText}
+            onChange={(e) => setImportUnitText(e.target.value)}
+            className="border border-[var(--border)] p-1 w-full h-24"
+          />
+          <input
+            type="file"
+            accept="application/json"
+            onChange={(e) => readFile(e, setImportUnitText)}
+          />
+          <button onClick={submitUnitImport} className="button-send">
+            Import JSON
+          </button>
+        </div>
+      )}
       <table className="min-w-full border border-[var(--border)] text-left">
         <thead>
           <tr>

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -86,11 +86,17 @@ paths:
       summary: List synonyms
     post:
       summary: Create synonym
+  /synonyms/import:
+    post:
+      summary: Import synonyms from JSON
   /unit-synonyms:
     get:
       summary: List unit synonyms
     post:
       summary: Create unit synonym
+  /unit-synonyms/import:
+    post:
+      summary: Import unit synonyms from JSON
   /synonyms/{alias}:
     delete:
       summary: Delete synonym


### PR DESCRIPTION
## Summary
- allow importing ingredient synonyms in bulk
- allow importing unit synonyms in bulk
- expose new `/import` routes for synonyms
- update frontend API and page to import JSON mappings
- document routes in OpenAPI
- test synonym import API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68754b13b80083308d58efa2e40bfaef