### PR TITLE
Enhance shopping list grouping and canonical names

### DIFF
--- a/backend/app/api/shopping_list.py
+++ b/backend/app/api/shopping_list.py
@@ -11,7 +11,11 @@ def list_items(skip: int = 0, limit: int = 100, db: Session = Depends(session.ge
     return crud.list_shopping_list_items(db, skip=skip, limit=limit)
 
 
-@router.post("/from-recipe/{recipe_id}", response_model=list[schemas.ShoppingListItemWithIngredient], status_code=201)
+@router.post(
+    "/from-recipe/{recipe_id}",
+    response_model=list[schemas.ShoppingListItemWithIngredient],
+    status_code=201,
+)
 def add_from_recipe(recipe_id: int, db: Session = Depends(session.get_db)):
     items = crud.add_missing_ingredients_to_shopping_list(db, recipe_id)
     if items is None:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -188,5 +188,7 @@ class ShoppingListItem(Base):
     id = Column(Integer, primary_key=True, index=True)
     ingredient_id = Column(Integer, ForeignKey("ingredients.id"), nullable=False)
     quantity = Column(Integer, default=1)
+    recipe_id = Column(Integer, ForeignKey("recipes.id"), nullable=True)
 
     ingredient = relationship("Ingredient")
+    recipe = relationship("Recipe")

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 from typing import Optional, List
 
+
 class UnitBase(BaseModel):
     name: str
     symbol: Optional[str] = None
@@ -16,14 +17,17 @@ class Unit(UnitBase):
     class Config:
         orm_mode = True
 
+
 class IngredientBase(BaseModel):
     name: str
     type: Optional[str] = None
     barcode: Optional[str] = None
     notes: Optional[str] = None
 
+
 class IngredientCreate(IngredientBase):
     pass
+
 
 class Ingredient(IngredientBase):
     id: int
@@ -31,24 +35,29 @@ class Ingredient(IngredientBase):
     class Config:
         orm_mode = True
 
+
 class RecipeBase(BaseModel):
     name: str
     alcoholic: Optional[str] = None
     instructions: Optional[str] = None
     thumb: Optional[str] = None
 
+
 class RecipeIngredientBase(BaseModel):
     name: str
     measure: Optional[str] = None
 
+
 class RecipeIngredientCreate(RecipeIngredientBase):
     pass
+
 
 class RecipeIngredient(RecipeIngredientBase):
     id: int
 
     class Config:
         orm_mode = True
+
 
 class Tag(BaseModel):
     id: int
@@ -57,12 +66,14 @@ class Tag(BaseModel):
     class Config:
         orm_mode = True
 
+
 class Category(BaseModel):
     id: int
     name: str
 
     class Config:
         orm_mode = True
+
 
 class Iba(BaseModel):
     id: int
@@ -78,6 +89,7 @@ class RecipeCreate(RecipeBase):
     ibas: List[str] = []
     ingredients: List[RecipeIngredientCreate] = []
 
+
 class Recipe(RecipeBase):
     id: int
     tags: List[Tag] = []
@@ -91,6 +103,7 @@ class Recipe(RecipeBase):
 
 class RecipeWithInventory(Recipe):
     """Recipe details along with inventory availability info."""
+
     available_count: int
     missing_count: int
 
@@ -100,12 +113,14 @@ class RecipeWithInventory(Recipe):
 
 class RecipeIngredientWithInventory(RecipeIngredient):
     """Recipe ingredient including current inventory quantity."""
+
     inventory_item_id: int | None = None
     inventory_quantity: int = 0
 
 
 class RecipeDetail(Recipe):
     """Full recipe data with inventory info for each ingredient."""
+
     ingredients: List[RecipeIngredientWithInventory] = []
 
 
@@ -114,12 +129,15 @@ class InventoryItemBase(BaseModel):
     quantity: int
     status: Optional[str] = None
 
+
 class InventoryItemCreate(InventoryItemBase):
     pass
+
 
 class InventoryItemUpdate(BaseModel):
     quantity: Optional[int] = None
     status: Optional[str] = None
+
 
 class InventoryItem(InventoryItemBase):
     id: int
@@ -149,6 +167,7 @@ class BarcodeCache(BaseModel):
 class ShoppingListItemBase(BaseModel):
     ingredient_id: int
     quantity: int = 1
+    recipe_id: int | None = None
 
 
 class ShoppingListItemCreate(ShoppingListItemBase):
@@ -164,3 +183,4 @@ class ShoppingListItem(ShoppingListItemBase):
 
 class ShoppingListItemWithIngredient(ShoppingListItem):
     ingredient: Ingredient
+    recipe: Recipe | None = None

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -44,6 +44,11 @@ export interface RecipeIngredient {
   inventory_quantity: number;
 }
 
+export interface Recipe {
+  id: number;
+  name: string;
+}
+
 export interface RecipeDetail {
   id: number;
   name: string;
@@ -252,6 +257,8 @@ export interface ShoppingListItem {
   ingredient_id: number;
   quantity: number;
   ingredient?: Ingredient;
+  recipe_id?: number | null;
+  recipe?: Recipe | null;
 }
 
 export async function listShoppingList() {

--- a/frontend/src/pages/ShoppingList.tsx
+++ b/frontend/src/pages/ShoppingList.tsx
@@ -2,15 +2,33 @@ import { useEffect, useState } from 'react';
 import {
   listShoppingList,
   clearShoppingList,
+  listSynonyms,
   type ShoppingListItem,
+  type Synonym,
 } from '../api';
 
 export default function ShoppingList() {
   const [items, setItems] = useState<ShoppingListItem[]>([]);
+  const [synonyms, setSynonyms] = useState<Synonym[]>([]);
+
+  const synonymsMap = Object.fromEntries(
+    synonyms.map((s) => [s.alias.toLowerCase(), s.canonical]),
+  );
+
+  const canonical = (n: string | undefined) => {
+    if (!n) return null;
+    const key = n.trim().toLowerCase();
+    const cand = synonymsMap[key];
+    if (!cand || cand.toLowerCase() === key) return null;
+    return cand.charAt(0).toUpperCase() + cand.slice(1);
+  };
 
   useEffect(() => {
     listShoppingList().then(({ data }) => {
       if (data) setItems(data);
+    });
+    listSynonyms().then(({ data }) => {
+      if (data) setSynonyms(data);
     });
   }, []);
 
@@ -33,6 +51,23 @@ export default function ShoppingList() {
     URL.revokeObjectURL(url);
   };
 
+  const itemsByRecipe = items.reduce<Record<number | string, ShoppingListItem[]>>(
+    (acc, it) => {
+      const key = it.recipe ? it.recipe.id : "other";
+      if (!acc[key]) acc[key] = [];
+      acc[key].push(it);
+      return acc;
+    },
+    {},
+  );
+
+  const aggregated = items.reduce<Record<string, number>>((acc, it) => {
+    const name = it.ingredient?.name || String(it.ingredient_id);
+    const key = (synonymsMap[name.toLowerCase()] || name).toLowerCase();
+    acc[key] = (acc[key] || 0) + it.quantity;
+    return acc;
+  }, {});
+
   return (
     <div className="space-y-6">
       <h1 className="font-display text-3xl font-semibold">Shopping List</h1>
@@ -44,17 +79,47 @@ export default function ShoppingList() {
           Reset
         </button>
       </div>
-      <div className="card p-0">
-        <ul className="divide-y divide-[var(--border)]">
-          {items.map((it) => (
-            <li key={it.id} className="flex items-center justify-between p-4">
-              <span>
-                {it.quantity} x {it.ingredient?.name || it.ingredient_id}
-              </span>
-            </li>
-          ))}
-        </ul>
+      <div className="space-y-4">
+        {Object.entries(itemsByRecipe).map(([key, list]) => (
+          <div key={key} className="card p-0">
+            <h2 className="px-4 py-2 font-semibold">
+              {list[0].recipe ? list[0].recipe.name : "Other"}
+            </h2>
+            <ul className="divide-y divide-[var(--border)]">
+              {list.map((it) => (
+                <li
+                  key={it.id}
+                  className="flex items-center justify-between p-4"
+                >
+                  <span>
+                    {it.quantity} x {it.ingredient?.name || it.ingredient_id}
+                    {canonical(it.ingredient?.name) && (
+                      <span className="text-sm text-[var(--text-secondary)] ml-1">
+                        ({canonical(it.ingredient?.name)})
+                      </span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
       </div>
+
+      {Object.keys(aggregated).length > 0 && (
+        <div className="card p-0">
+          <h2 className="px-4 py-2 font-semibold">All Ingredients</h2>
+          <ul className="divide-y divide-[var(--border)]">
+            {Object.entries(aggregated).map(([name, qty]) => (
+              <li key={name} className="flex items-center justify-between p-4">
+                <span>
+                  {qty} x {name.charAt(0).toUpperCase() + name.slice(1)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `recipe_id` foreign key to `ShoppingListItem`
- track recipe when adding missing ingredients
- expose recipe info in shopping list schema
- display canonical ingredient names and group items by recipe in the UI
- include aggregated ingredient totals
- adjust unit tests for updated API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875700853088330b0f55edaa595a1c0