### PR TITLE
Separate recipe search route

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -16,24 +16,6 @@ async def search_recipes_endpoint(q: str):
     return await search_recipes_details(q)
 
 
-@router.get("/find", response_model=list[schemas.RecipeWithInventory])
-def find_recipes(
-    q: str | None = None,
-    available_only: bool = False,
-    order_missing: bool = False,
-    skip: int = 0,
-    limit: int = 100,
-    db: Session = Depends(session.get_db),
-):
-    """Search recipes stored locally with optional inventory filters."""
-    return crud.search_local_recipes(
-        db,
-        query=q,
-        available_only=available_only,
-        order_missing=order_missing,
-        skip=skip,
-        limit=limit,
-    )
 
 @router.get("/", response_model=list[schemas.Recipe])
 def list_recipes(skip: int = 0, limit: int = 100, db: Session = Depends(session.get_db)):

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..db import crud, schemas, session
+
+router = APIRouter()
+
+
+@router.get("", response_model=list[schemas.RecipeWithInventory])
+def find_recipes(
+    q: str | None = None,
+    available_only: bool = False,
+    order_missing: bool = False,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(session.get_db),
+):
+    """Search recipes stored locally with optional inventory filters."""
+    return crud.search_local_recipes(
+        db,
+        query=q,
+        available_only=available_only,
+        order_missing=order_missing,
+        skip=skip,
+        limit=limit,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from .api import (
     recipes,
     inventory,
     barcode,
+    search,
     synonyms,
     unit_synonyms,
     shopping_list,
@@ -48,6 +49,7 @@ app.include_router(ingredients.router, prefix="/ingredients")
 app.include_router(recipes.router, prefix="/recipes")
 app.include_router(inventory.router, prefix="/inventory")
 app.include_router(barcode.router, prefix="/barcode")
+app.include_router(search.router, prefix="/search")
 app.include_router(synonyms.router, prefix="/synonyms")
 app.include_router(unit_synonyms.router, prefix="/unit-synonyms")
 app.include_router(shopping_list.router, prefix="/shopping-list")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -509,7 +509,7 @@ async def test_recipe_find_inventory(monkeypatch, async_client):
     await async_client.post("/recipes/", json={"name": "vodka gin"})
 
     resp = await async_client.get(
-        "/recipes/find", params={"available_only": True, "q": "vodka"}
+        "/search", params={"available_only": True, "q": "vodka"}
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -521,7 +521,7 @@ async def test_recipe_find_inventory(monkeypatch, async_client):
     assert vo["missing_count"] == 0
 
     resp = await async_client.get(
-        "/recipes/find", params={"order_missing": True, "q": "vodka"}
+        "/search", params={"order_missing": True, "q": "vodka"}
     )
     assert resp.status_code == 200
     data = resp.json()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
           <Route path="/" element={<Dashboard />} />
           <Route path="/inventory" element={<Inventory />} />
           <Route path="/recipes" element={<Recipes />} />
-          <Route path="/recipes/find" element={<FindRecipes />} />
+          <Route path="/search" element={<FindRecipes />} />
           <Route path="/recipes/:id" element={<RecipeDetail />} />
           <Route path="/shopping-list" element={<ShoppingList />} />
           <Route path="/stats" element={<Stats />} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -171,7 +171,7 @@ export async function findRecipes(options: FindRecipesOptions = {}) {
     params.append("limit", String(options.limit));
   const query = params.toString();
   const res = await fetch(
-    `${API_BASE}/recipes/find${query ? `?${query}` : ""}`,
+    `${API_BASE}/search${query ? `?${query}` : ""}`,
   );
   return res.json();
 }

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -30,7 +30,7 @@ export default function Navbar() {
           <NavLink to="/recipes" className={linkClass}>
             Recipes
           </NavLink>
-          <NavLink to="/recipes/find" className={linkClass}>
+          <NavLink to="/search" className={linkClass}>
             Recipe Finder
           </NavLink>
           <NavLink to="/shopping-list" className={linkClass}>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ export default function Dashboard() {
   const features = [
     { to: '/inventory', title: 'Inventory', icon: <Box size={20} /> },
     { to: '/recipes', title: 'Recipes', icon: <BookOpen size={20} /> },
-    { to: '/recipes/find', title: 'Recipe Finder', icon: <Search size={20} /> },
+    { to: '/search', title: 'Recipe Finder', icon: <Search size={20} /> },
     { to: '/shopping-list', title: 'Shopping List', icon: <ClipboardList size={20} /> },
     { to: '/stats', title: 'Stats', icon: <BarChart2 size={20} /> },
     { to: '/synonyms', title: 'Synonyms', icon: <Replace size={20} /> },

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -25,7 +25,7 @@ paths:
           name: q
           schema:
             type: string
-  /recipes/find:
+  /search:
     get:
       summary: Search local recipes
       parameters:


### PR DESCRIPTION
## Summary
- move `find_recipes` to new `search` router
- expose the new router under `/search`
- update tests and openapi spec
- adjust frontend links to new search path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687604b130888330a7e8cf11d242bdb9