### PR TITLE
Add tag display for recipes

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -11,7 +11,7 @@ from ..services.cocktaildb import (
 router = APIRouter()
 
 
-@router.get("/search", response_model=list[schemas.RecipeBase])
+@router.get("/search", response_model=list[schemas.RecipePreview])
 async def search_recipes_endpoint(q: str):
     return await search_recipes_details(q)
 

--- a/backend/app/db/schemas.py
+++ b/backend/app/db/schemas.py
@@ -90,6 +90,14 @@ class RecipeCreate(RecipeBase):
     ingredients: List[RecipeIngredientCreate] = []
 
 
+class RecipePreview(RecipeBase):
+    """Basic recipe info including tags used for search results."""
+
+    tags: List[str] = []
+    categories: List[str] = []
+    ibas: List[str] = []
+
+
 class Recipe(RecipeBase):
     id: int
     tags: List[Tag] = []

--- a/backend/app/services/cocktaildb.py
+++ b/backend/app/services/cocktaildb.py
@@ -28,7 +28,7 @@ async def search_recipes(name: str) -> list[str]:
 
 
 async def search_recipes_details(name: str) -> list[dict]:
-    """Return basic recipe information for matches."""
+    """Return basic recipe information for matches including tags."""
     url = f"{API_BASE}/search.php"
     params = {"s": name}
     async with httpx.AsyncClient() as client:
@@ -38,12 +38,18 @@ async def search_recipes_details(name: str) -> list[dict]:
         drinks = data.get("drinks") or []
         results = []
         for d in drinks:
+            tags = [t.strip() for t in (d.get("strTags") or "").split(",") if t.strip()]
+            categories = [c.strip() for c in (d.get("strCategory") or "").split(",") if c.strip()]
+            ibas = [i.strip() for i in (d.get("strIBA") or "").split(",") if i.strip()]
             results.append(
                 {
                     "name": d.get("strDrink"),
                     "alcoholic": d.get("strAlcoholic"),
                     "instructions": d.get("strInstructions"),
                     "thumb": d.get("strDrinkThumb"),
+                    "tags": tags,
+                    "categories": categories,
+                    "ibas": ibas,
                 }
             )
         return results

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -128,12 +128,18 @@ async def test_recipe_search(monkeypatch, async_client):
                 "alcoholic": "Alcoholic",
                 "instructions": "Mix",
                 "thumb": "http://example.com/margarita.jpg",
+                "tags": [],
+                "categories": [],
+                "ibas": [],
             },
             {
                 "name": "Blue Margarita",
                 "alcoholic": "Alcoholic",
                 "instructions": "Mix blue",
                 "thumb": "http://example.com/blue.jpg",
+                "tags": [],
+                "categories": [],
+                "ibas": [],
             },
         ]
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -49,11 +49,29 @@ export interface Recipe {
   name: string;
 }
 
+export interface RecipeSearchResult {
+  name: string;
+  alcoholic?: string | null;
+  instructions?: string | null;
+  thumb?: string | null;
+  tags?: string[];
+  categories?: string[];
+  ibas?: string[];
+}
+
+export interface NamedItem {
+  id: number;
+  name: string;
+}
+
 export interface RecipeDetail {
   id: number;
   name: string;
   instructions?: string | null;
   thumb?: string | null;
+  tags?: NamedItem[];
+  categories?: NamedItem[];
+  ibas?: NamedItem[];
   ingredients: RecipeIngredient[];
 }
 
@@ -146,7 +164,7 @@ export async function listRecipes() {
   return res.json();
 }
 
-export async function searchRecipes(q: string) {
+export async function searchRecipes(q: string): Promise<RecipeSearchResult[]> {
   const res = await fetch(
     `${API_BASE}/recipes/search?q=${encodeURIComponent(q)}`,
   );

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -67,6 +67,19 @@ export default function RecipeDetail() {
         )}
         <div>
           <h1 className="text-3xl font-bold mb-2 font-display">{recipe.name}</h1>
+          {(recipe.categories?.length || recipe.tags?.length || recipe.ibas?.length) && (
+            <div className="space-y-1 mb-2 text-sm text-[var(--text-secondary)]">
+              {recipe.categories && recipe.categories.length > 0 && (
+                <p>Category: {recipe.categories.map((c) => c.name).join(', ')}</p>
+              )}
+              {recipe.tags && recipe.tags.length > 0 && (
+                <p>Tags: {recipe.tags.map((t) => t.name).join(', ')}</p>
+              )}
+              {recipe.ibas && recipe.ibas.length > 0 && (
+                <p>IBA: {recipe.ibas.map((i) => i.name).join(', ')}</p>
+              )}
+            </div>
+          )}
           {recipe.instructions && <p className="mb-4">{recipe.instructions}</p>}
           <button
             onClick={async () => {

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -11,6 +11,9 @@ interface Recipe {
   alcoholic?: string | null;
   instructions?: string | null;
   thumb?: string | null;
+  tags?: string[];
+  categories?: string[];
+  ibas?: string[];
 }
 
 export default function Recipes() {
@@ -129,9 +132,22 @@ export default function Recipes() {
                           )}
                           {/* Instructions section */}
                           {r.instructions && (
-                            <div className="ml-2 flex-1 min-w-[500px] max-w-[700px]">
+                            <div className="ml-2 flex-1 min-w-[500px] max-w-[700px] space-y-2">
                               <h3 className="font-semibold text-[var(--text-primary)] mb-1">Instructions</h3>
                               <p>{r.instructions}</p>
+                              {(r.categories?.length || r.tags?.length || r.ibas?.length) && (
+                                <div className="space-y-1 text-[var(--text-secondary)]">
+                                  {r.categories && r.categories.length > 0 && (
+                                    <p>Category: {r.categories.join(', ')}</p>
+                                  )}
+                                  {r.tags && r.tags.length > 0 && (
+                                    <p>Tags: {r.tags.join(', ')}</p>
+                                  )}
+                                  {r.ibas && r.ibas.length > 0 && (
+                                    <p>IBA: {r.ibas.join(', ')}</p>
+                                  )}
+                                </div>
+                              )}
                             </div>
                           )}
                         </div>
@@ -205,9 +221,22 @@ export default function Recipes() {
                           )}
                           {/* Instructions section */}
                           {s.instructions && (
-                            <div className="ml-2 flex-1 min-w-[300px] max-w-[500px]">
+                            <div className="ml-2 flex-1 min-w-[300px] max-w-[500px] space-y-2">
                               <h3 className="font-semibold text-[var(--text-primary)] mb-1">Instructions</h3>
                               <p>{s.instructions}</p>
+                              {(s.categories?.length || s.tags?.length || s.ibas?.length) && (
+                                <div className="space-y-1 text-[var(--text-secondary)]">
+                                  {s.categories && s.categories.length > 0 && (
+                                    <p>Category: {s.categories.join(', ')}</p>
+                                  )}
+                                  {s.tags && s.tags.length > 0 && (
+                                    <p>Tags: {s.tags.join(', ')}</p>
+                                  )}
+                                  {s.ibas && s.ibas.length > 0 && (
+                                    <p>IBA: {s.ibas.join(', ')}</p>
+                                  )}
+                                </div>
+                              )}
                             </div>
                           )}
                         </div>


### PR DESCRIPTION
## Summary
- include tags, categories and IBA data from CocktailDB search
- expose this information via new `RecipePreview` schema
- extend frontend API typings with tag data
- show categories/tags/IBA in Recipe detail page and search results
- adjust API test for new fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68760e7031448330a37f94276369d609