### PR TITLE
Add reusable recipe list component

### DIFF
--- a/frontend/src/components/RecipeList.tsx
+++ b/frontend/src/components/RecipeList.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import type { NamedItem } from '../api';
+import type { ReactNode } from 'react';
+
+export interface RecipeItem {
+  id?: number;
+  name: string;
+  alcoholic?: string | NamedItem | null;
+  instructions?: string | null;
+  thumb?: string | null;
+  tags?: (string | NamedItem)[];
+  categories?: (string | NamedItem)[];
+  ibas?: (string | NamedItem)[];
+  available_count?: number;
+  missing_count?: number;
+}
+
+interface RecipeListProps {
+  recipes: RecipeItem[];
+  renderAction?: (recipe: RecipeItem) => ReactNode;
+  showCounts?: boolean;
+}
+
+export default function RecipeList({
+  recipes,
+  renderAction,
+  showCounts,
+}: RecipeListProps) {
+  const [expanded, setExpanded] = useState<number | string | null>(null);
+
+  const getName = (value: string | NamedItem | undefined | null) =>
+    typeof value === 'string' || value === null || value === undefined
+      ? value
+      : value.name;
+
+  const joinNames = (items: (string | NamedItem)[] | undefined) =>
+    items?.map((i) => (typeof i === 'string' ? i : i.name)).join(', ');
+
+  return (
+    <div className="card p-0">
+      <ul className="divide-y divide-[var(--border)]">
+        {recipes.map((r, idx) => {
+          const key = r.id ?? idx;
+          const expandedKey = expanded === key;
+          return (
+            <li key={key}>
+              <div
+                className="flex items-center gap-2 p-4 cursor-pointer mb-[5px] mt-[5px]"
+                onClick={() => setExpanded(expandedKey ? null : key)}
+              >
+                <span className="flex-1 truncate font-semibold">{r.name}</span>
+                {showCounts &&
+                  typeof r.available_count === 'number' &&
+                  typeof r.missing_count === 'number' && (
+                    <span className="text-sm text-[var(--text-secondary)]">
+                      {r.available_count} available / {r.missing_count} missing
+                    </span>
+                  )}
+                {renderAction && (
+                  <span onClick={(e) => e.stopPropagation()}>{renderAction(r)}</span>
+                )}
+              </div>
+              {expandedKey && (
+                <div className="flex h-52 w-full space-x-4 p-2 text-sm text-[var(--text-muted)] mb-4">
+                  {r.thumb && (
+                    <img
+                      src={r.thumb}
+                      alt={r.name}
+                      className="h-48 w-48 rounded object-cover"
+                    />
+                  )}
+                  <div className="flex flex-row items-start w-full">
+                    <div className="flex flex-col justify-start items-start w-32 min-w-[100px]">
+                      {r.alcoholic && (
+                        <div className="flex items-center space-x-2 mb-2">
+                          <p>{getName(r.alcoholic)}</p>
+                          {getName(r.alcoholic) === 'Alcoholic' && (
+                            <span title="Alcoholic">
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="20"
+                                height="20"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <circle
+                                  cx="10"
+                                  cy="10"
+                                  r="8"
+                                  stroke="currentColor"
+                                  strokeWidth="2"
+                                  fill="none"
+                                />
+                                <text
+                                  x="10"
+                                  y="14"
+                                  textAnchor="middle"
+                                  fontSize="10"
+                                  fill="currentColor"
+                                >
+                                  %
+                                </text>
+                              </svg>
+                            </span>
+                          )}
+                        </div>
+                      )}
+                      {r.categories && r.categories.length > 0 && (
+                        <div className="mb-2">
+                          <h4 className="font-semibold text-[var(--text-primary)]">Category</h4>
+                          <p>{joinNames(r.categories)}</p>
+                        </div>
+                      )}
+                      {r.tags && r.tags.length > 0 && (
+                        <div className="mb-2">
+                          <h4 className="font-semibold text-[var(--text-primary)]">Tags</h4>
+                          <p>{joinNames(r.tags)}</p>
+                        </div>
+                      )}
+                      {r.ibas && r.ibas.length > 0 && (
+                        <div>
+                          <h4 className="font-semibold text-[var(--text-primary)]">IBA</h4>
+                          <p>{joinNames(r.ibas)}</p>
+                        </div>
+                      )}
+                    </div>
+                    {r.instructions && (
+                      <div className="ml-4 flex-1 min-w-[300px] max-w-[700px] space-y-2">
+                        <h3 className="font-semibold text-[var(--text-primary)] mb-1">Instructions</h3>
+                        <p>{r.instructions}</p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/FindRecipes.tsx
+++ b/frontend/src/pages/FindRecipes.tsx
@@ -2,33 +2,15 @@ import { useState } from "react";
 import { findRecipes } from "../api";
 import { Link } from "react-router-dom";
 import { Search } from "lucide-react";
+import RecipeList, { type RecipeItem } from "../components/RecipeList";
 
-interface NamedItem {
-  id: number;
-  name: string;
-}
-
-interface Recipe {
-  id: number;
-  name: string;
-  alcoholic?: string | NamedItem | null;
-  instructions?: string | null;
-  thumb?: string | null;
-  available_count?: number;
-  missing_count?: number;
-}
+type Recipe = RecipeItem;
 
 export default function FindRecipes() {
   const [query, setQuery] = useState("");
   const [availableOnly, setAvailableOnly] = useState(false);
   const [orderMissing, setOrderMissing] = useState(false);
   const [results, setResults] = useState<Recipe[]>([]);
-  const [expanded, setExpanded] = useState<number | null>(null);
-
-  const getName = (value: string | NamedItem | undefined | null) =>
-    typeof value === 'string' || value === null || value === undefined
-      ? value
-      : value.name;
 
   const runSearch = async () => {
     const data = await findRecipes({
@@ -72,73 +54,15 @@ export default function FindRecipes() {
         </label>
       </div>
       {results.length > 0 && (
-        <div className="card p-0">
-          <ul className="divide-y divide-[var(--border)]">
-            {results.map((r) => {
-              const expandedKey = expanded === r.id;
-              return (
-                <li key={r.id}>
-                  <div
-                    className="flex items-center gap-2 p-4 cursor-pointer mb-[5px] mt-[5px]"
-                    onClick={() => setExpanded(expandedKey ? null : r.id)}
-                  >
-                    <span className="flex-1 truncate font-semibold">
-                      {r.name}
-                    </span>
-                    {typeof r.available_count === "number" && typeof r.missing_count === "number" && (
-                      <span className="text-sm text-[var(--text-secondary)]">
-                        {r.available_count} available / {r.missing_count} missing
-                      </span>
-                    )}
-                    <Link
-                      to={`/recipes/${r.id}`}
-                      onClick={(e) => e.stopPropagation()}
-                      className="button-search"
-                    >
-                      Open
-                    </Link>
-                  </div>
-                  {expandedKey && (
-                    <div className="flex h-52 w-96 space-x-4 p-2 text-sm text-[var(--text-muted)] mb-4">
-                      {/* Recipe thumbnail */}
-                      {r.thumb && (
-                        <img
-                          src={r.thumb}
-                          alt={r.name}
-                          className="h-48 w-48 rounded object-cover"
-                        />
-                      )}
-                      <div className="flex flex-row items-start space-x-16 w-full">
-                        {/* Alcoholic info with promille icon if alcoholic */}
-                        {r.alcoholic && (
-                          <div className="ml-16 flex items-center space-x-2">
-                            <p>{getName(r.alcoholic)}</p>
-                            {getName(r.alcoholic) === "Alcoholic" && (
-                              <span title="Alcoholic">
-                                {/* Promille SVG icon */}
-                                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 20 20">
-                                  <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" fill="none" />
-                                  <text x="10" y="14" textAnchor="middle" fontSize="10" fill="currentColor">%</text>
-                                </svg>
-                              </span>
-                            )}
-                          </div>
-                        )}
-                        {/* Instructions section */}
-                        {r.instructions && (
-                          <div className="ml-2 flex-1 min-w-[300px] max-w-[500px]">
-                            <h3 className="font-semibold text-[var(--text-primary)] mb-1">Instructions</h3>
-                            <p>{r.instructions}</p>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        <RecipeList
+          recipes={results}
+          showCounts
+          renderAction={(r) => (
+            <Link to={`/recipes/${r.id}`} className="button-search">
+              Open
+            </Link>
+          )}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -3,30 +3,16 @@ import { useEffect, useState } from 'react';
 import { listRecipes, searchRecipes, createRecipe } from '../api';
 import { Link } from 'react-router-dom';
 import { Search } from 'lucide-react';
+import RecipeList, { type RecipeItem } from '../components/RecipeList';
 
-// Recipe interface for type safety
-interface NamedItem {
-  id: number;
-  name: string;
-}
-
-interface Recipe {
-  id?: number;
-  name: string;
-  alcoholic?: string | NamedItem | null;
-  instructions?: string | null;
-  thumb?: string | null;
-  tags?: (string | NamedItem)[];
-  categories?: (string | NamedItem)[];
-  ibas?: (string | NamedItem)[];
-}
+// Reuse RecipeItem type from RecipeList component
+type Recipe = RecipeItem;
 
 export default function Recipes() {
-  // State for search query, search results, saved recipes, and expanded recipe details
+  // State for search query, search results and saved recipes
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<Recipe[]>([]);
   const [saved, setSaved] = useState<Recipe[]>([]);
-  const [expanded, setExpanded] = useState<string | null>(null);
 
   // Fetch saved recipes from backend
   const refresh = () => {
@@ -46,13 +32,6 @@ export default function Recipes() {
     setResults(res.filter((r: Recipe) => !saved.some((s) => s.name === r.name)));
   };
 
-  const getName = (value: string | NamedItem | undefined | null) =>
-    typeof value === 'string' || value === null || value === undefined
-      ? value
-      : value.name;
-
-  const joinNames = (items: (string | NamedItem)[] | undefined) =>
-    items?.map((i) => (typeof i === 'string' ? i : i.name)).join(', ');
 
   // Save a recipe by name, refresh saved list, remove from search results
   const save = async (name: string) => {
@@ -85,195 +64,31 @@ export default function Recipes() {
       {/* Search results section */}
       {results.length > 0 && (
         <div className="space-y-2">
-          <h2 className="font-semibold">
-            Results ({results.length})
-          </h2>
-          <div className="card p-0">
-            <ul className="divide-y divide-[var(--border)]">
-              {results.map((r) => {
-                const key = `search-${r.name}`;
-                const expandedKey = expanded === key;
-                return (
-                  <li key={key}>
-                    <div
-                      className="flex items-center gap-2 p-4 cursor-pointer mb-[5px] mt-[5px]"
-                      onClick={() =>
-                        setExpanded(expandedKey ? null : key)
-                      }
-                    >
-                      {/* Recipe name */}
-                      <span className="flex-1 truncate font-semibold">
-                        {r.name}
-                      </span>
-                      {/* Add button for unsaved recipes */}
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          save(r.name);
-                        }}
-                        className="button-search"
-                      >
-                        Add
-                      </button>
-                    </div>
-                    {/* Expanded recipe details */}
-                    {expandedKey && (
-                      <div className="flex h-52 w-full space-x-4 p-2 text-sm text-[var(--text-muted)] mb-4">
-                        {/* Recipe thumbnail */}
-                        {r.thumb && (
-                          <img
-                            src={r.thumb}
-                            alt={r.name}
-                            className="h-48 w-48 rounded object-cover"
-                          />
-                        )}
-                        <div className="flex flex-row items-start w-full">
-                          {/* Alcoholic info with promille icon if alcoholic */}
-                          <div className="flex flex-col justify-start items-start w-32 min-w-[100px]">
-                            {r.alcoholic && (
-                              <div className="flex items-center space-x-2 mb-2">
-                                <p>{getName(r.alcoholic)}</p>
-                                {getName(r.alcoholic) === "Alcoholic" && (
-                                  <span title="Alcoholic">
-                                    {/* Promille SVG icon */}
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 20 20">
-                                      <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" fill="none" />
-                                      <text x="10" y="14" textAnchor="middle" fontSize="10" fill="currentColor">%</text>
-                                    </svg>
-                                  </span>
-                                )}
-                              </div>
-                            )}
-                            {r.categories && r.categories.length > 0 && (
-                              <div className="mb-2">
-                                <h4 className="font-semibold text-[var(--text-primary)]">Category</h4>
-                                <p>{joinNames(r.categories)}</p>
-                              </div>
-                            )}
-                            {r.tags && r.tags.length > 0 && (
-                              <div className="mb-2">
-                                <h4 className="font-semibold text-[var(--text-primary)]">Tags</h4>
-                                <p>{joinNames(r.tags)}</p>
-                              </div>
-                            )}
-                            {r.ibas && r.ibas.length > 0 && (
-                              <div>
-                                <h4 className="font-semibold text-[var(--text-primary)]">IBA</h4>
-                                <p>{joinNames(r.ibas)}</p>
-                              </div>
-                            )}
-                          </div>
-                          {/* Instructions section */}
-                          {r.instructions && (
-                            <div className="ml-4 flex-1 min-w-[300px] max-w-[700px] space-y-2">
-                              <h3 className="font-semibold text-[var(--text-primary)] mb-1">Instructions</h3>
-                              <p>{r.instructions}</p>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
+          <h2 className="font-semibold">Results ({results.length})</h2>
+          <RecipeList
+            recipes={results}
+            renderAction={(r) => (
+              <button onClick={() => save(r.name)} className="button-search">
+                Add
+              </button>
+            )}
+          />
         </div>
       )}
       {/* Saved recipes section */}
       {saved.length > 0 && (
         <div className="space-y-2">
           <h2 className="font-semibold">Saved Recipes</h2>
-          <div className="card p-0">
-            <ul className="divide-y divide-[var(--border)]">
-              {saved.map((s) => {
-                const key = `saved-${s.id || s.name}`;
-                const expandedKey = expanded === key;
-                return (
-                  <li key={key}>
-                    <div
-                      className="flex items-center gap-2 p-4 cursor-pointer mb-[5px] mt-[5px]"
-                      onClick={() =>
-                        setExpanded(expandedKey ? null : key)
-                      }
-                    >
-                      {/* Recipe name */}
-                      <span className="flex-1 truncate font-semibold">
-                        {s.name}
-                      </span>
-                      {/* Link to recipe detail page if id exists */}
-                      {s.id && (
-                        <Link
-                          to={`/recipes/${s.id}`}
-                          onClick={(e) => e.stopPropagation()}
-                          className="button-search"
-                        >
-                          Open
-                        </Link>
-                      )}
-                    </div>
-                    {/* Expanded saved recipe details */}
-                    {expandedKey && (
-                      <div className="flex h-52 w-full space-x-4 p-2 text-sm text-[var(--text-muted)] mb-4">
-                        {/* Recipe thumbnail */}
-                        {s.thumb && (
-                          <img
-                            src={s.thumb}
-                            alt={s.name}
-                            className="h-48 w-48 rounded object-cover"
-                          />
-                        )}
-                        <div className="flex flex-row items-start w-full">
-                          {/* Alcoholic info with promille icon if alcoholic */}
-                          <div className="flex flex-col justify-start items-start w-32 min-w-[100px]">
-                            {s.alcoholic && (
-                              <div className="flex items-center space-x-2 mb-2">
-                                <p>{getName(s.alcoholic)}</p>
-                                {getName(s.alcoholic) === "Alcoholic" && (
-                                  <span title="Alcoholic">
-                                    {/* Promille SVG icon */}
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 20 20">
-                                      <circle cx="10" cy="10" r="8" stroke="currentColor" strokeWidth="2" fill="none" />
-                                      <text x="10" y="14" textAnchor="middle" fontSize="10" fill="currentColor">%</text>
-                                    </svg>
-                                  </span>
-                                )}
-                              </div>
-                            )}
-                            {s.categories && s.categories.length > 0 && (
-                              <div className="mb-2">
-                                <h4 className="font-semibold text-[var(--text-primary)]">Category</h4>
-                                <p>{joinNames(s.categories)}</p>
-                              </div>
-                            )}
-                            {s.tags && s.tags.length > 0 && (
-                              <div className="mb-2">
-                                <h4 className="font-semibold text-[var(--text-primary)]">Tags</h4>
-                                <p>{joinNames(s.tags)}</p>
-                              </div>
-                            )}
-                            {s.ibas && s.ibas.length > 0 && (
-                              <div>
-                                <h4 className="font-semibold text-[var(--text-primary)]">IBA</h4>
-                                <p>{joinNames(s.ibas)}</p>
-                              </div>
-                            )}
-                          </div>
-                          {/* Instructions section */}
-                          {s.instructions && (
-                            <div className="ml-4 flex-1 min-w-[300px] max-w-[500px] space-y-2">
-                              <h3 className="font-semibold text-[var(--text-primary)] mb-1">Instructions</h3>
-                              <p>{s.instructions}</p>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
+          <RecipeList
+            recipes={saved}
+            renderAction={(r) =>
+              r.id ? (
+                <Link to={`/recipes/${r.id}`} className="button-search">
+                  Open
+                </Link>
+              ) : null
+            }
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- create `RecipeList` component for listing recipe cards
- integrate `RecipeList` into Recipes and FindRecipes pages
- keep option to show available/missing counts for recipe finder

## Testing
- `npm run lint` *(fails: Unexpected any in existing code)*
- `pytest` *(fails: NameError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_687646a34d50833088bcaa741206c23f