### PR TITLE
Implement responsive mobile drawer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ export default function App() {
   return (
     <Router>
       <Navbar />
-      <main className="container mx-auto p-4">
+      <main className="mx-auto max-w-screen-xl px-4 md:px-6 py-4">
         {health && (
           <div className="mb-4 text-sm text-gray-500">Health: {health}</div>
         )}

--- a/frontend/src/components/Drawer.tsx
+++ b/frontend/src/components/Drawer.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export default function Drawer({ open, onClose, children }: DrawerProps) {
+  return (
+    <div
+      className={`fixed inset-0 z-50 transition ${open ? '' : 'pointer-events-none'}`}
+    >
+      <div
+        className={`absolute inset-0 bg-black/60 transition-opacity ${open ? 'opacity-100' : 'opacity-0'}`}
+        onClick={onClose}
+      />
+      <div
+        className={`absolute left-0 top-0 h-full w-[min(96vw,540px)] bg-[var(--bg-elevated)] shadow-brand transition-transform duration-200 ${open ? 'translate-x-0' : '-translate-x-full'}`}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,49 +1,76 @@
 import { NavLink } from "react-router-dom";
+import { Menu, X } from 'lucide-react';
+import { useState } from 'react';
+import Drawer from './Drawer';
 
 
 
 
 export default function Navbar() {
+  const [open, setOpen] = useState(false);
+
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     [
       "relative px-4 py-2 rounded-full font-semibold transition-all duration-300 no-underline",
       isActive
-        ? "bg-[var(--accent)] text-black shadow-md p-3 flex items-center justify-center" +
-          " pl-[10px] pr-[10px] pt-[5px] pb-[5px]"
+        ? "bg-[var(--accent)] text-black shadow-md" +
+          " p-3 flex items-center justify-center pl-[10px] pr-[10px] pt-[5px] pb-[5px]"
         : "text-[var(--text-muted)] hover:text-[var(--accent)] hover:bg-[var(--bg-primary)]",
       "hover:scale-105",
     ].join(" ");
 
+  const Links = () => (
+    <>
+      <NavLink to="/" className={linkClass} end onClick={() => setOpen(false)}>
+        Dashboard
+      </NavLink>
+      <NavLink to="/inventory" className={linkClass} onClick={() => setOpen(false)}>
+        Inventory
+      </NavLink>
+      <NavLink to="/recipes" className={linkClass} onClick={() => setOpen(false)}>
+        Recipes
+      </NavLink>
+      <NavLink to="/search" className={linkClass} onClick={() => setOpen(false)}>
+        Recipe Search
+      </NavLink>
+      <NavLink to="/shopping-list" className={linkClass} onClick={() => setOpen(false)}>
+        Shopping List
+      </NavLink>
+      <NavLink to="/stats" className={linkClass} onClick={() => setOpen(false)}>
+        Stats
+      </NavLink>
+      <NavLink to="/synonyms" className={linkClass} onClick={() => setOpen(false)}>
+        Synonyms
+      </NavLink>
+    </>
+  );
+
   return (
     <header className="bg-[var(--bg-elevated)] border-b border-[var(--border)] text-[var(--text-primary)] shadow-lg sticky top-0 z-50">
-      <nav className="container mx-auto flex items-center justify-between py-3 px-4">
+      <nav className="max-w-screen-xl mx-auto flex items-center justify-between py-3 px-4 md:px-6">
         <div className="flex items-center gap-3">
           <span className="text-3xl font-bold tracking-tight text-[var(--accent)]">Bartool</span>
         </div>
-        <div className="flex gap-4 md:gap-8 mr:gap-8">
-          <NavLink to="/" className={linkClass} end>
-            Dashboard
-          </NavLink>
-          <NavLink to="/inventory" className={linkClass}>
-            Inventory
-          </NavLink>
-          <NavLink to="/recipes" className={linkClass}>
-            Recipes
-          </NavLink>
-          <NavLink to="/search" className={linkClass}>
-            Recipe Search
-          </NavLink>
-          <NavLink to="/shopping-list" className={linkClass}>
-            Shopping List
-          </NavLink>
-          <NavLink to="/stats" className={linkClass}>
-            Stats
-          </NavLink>
-          <NavLink to="/synonyms" className={linkClass}>
-            Synonyms
-          </NavLink>
+        <button
+          className="md:hidden p-2 rounded hover:bg-[var(--bg-primary)]"
+          onClick={() => setOpen(true)}
+        >
+          <Menu size={20} />
+        </button>
+        <div className="hidden md:flex gap-4 md:gap-6">
+          <Links />
         </div>
       </nav>
+      <Drawer open={open} onClose={() => setOpen(false)}>
+        <div className="p-4 space-y-4">
+          <button className="p-2 rounded" onClick={() => setOpen(false)}>
+            <X size={20} />
+          </button>
+          <nav className="flex flex-col gap-2">
+            <Links />
+          </nav>
+        </div>
+      </Drawer>
     </header>
   );
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -51,7 +51,7 @@ export default function Dashboard() {
     <div className="space-y-6">
       <h1 className="text-3xl font-bold font-display">Dashboard</h1>
       <p className="text-[var(--text-muted)]">Welcome to BarTool. Select an action below.</p>
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-4">
         {features.map((f) => (
           f.action === 'export' ? (
             <button

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 import BarcodeScanner from '../components/BarcodeScanner'
+import Drawer from '../components/Drawer'
+import { X } from 'lucide-react'
 import {
   listInventory,
   createIngredient,
@@ -149,21 +151,17 @@ export default function Inventory() {
 
       <section className="space-y-4 p-4 mb-6 rounded-lg shadow">
         <h2 className="text-xl font-semibold">Barcode Lookup</h2>
-        {scanning ? (
-          <div>
-            <BarcodeScanner onDetected={onDetected} />
-            <button
-              onClick={() => setScanning(false)}
-              className="mt-2 rounded bg-gray-200 px-2 py-1"
-            >
-              Cancel
+        <button onClick={() => setScanning(true)} className="button-send">
+          Scan Barcode
+        </button>
+        <Drawer open={scanning} onClose={() => setScanning(false)}>
+          <div className="p-4 space-y-2">
+            <button className="p-2 rounded" onClick={() => setScanning(false)}>
+              <X size={20} />
             </button>
+            <BarcodeScanner onDetected={onDetected} />
           </div>
-        ) : (
-          <button onClick={() => setScanning(true)} className="button-send">
-            Scan Barcode
-          </button>
-        )}
+        </Drawer>
         <div className="flex gap-4 items-center">
           <input
             placeholder="Enter barcode"


### PR DESCRIPTION
## Summary
- add generic Drawer component
- use Drawer for navigation and barcode scanning
- tweak layouts for mobile/tablet based on style guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687691cc0dc08330b6d1af921275b463