### PR TITLE
Add tablet view toggle

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import { NavLink } from "react-router-dom";
 import { Menu, X } from "lucide-react";
 import { useState } from "react";
 import Drawer from "./Drawer";
+import TabletSwitch from "./TabletSwitch";
 
 
 
@@ -68,6 +69,7 @@ export default function Navbar() {
           <nav className="flex flex-col gap-2">
             <Links />
           </nav>
+          <TabletSwitch />
         </div>
       </Drawer>
     </header>

--- a/frontend/src/components/TabletSwitch.tsx
+++ b/frontend/src/components/TabletSwitch.tsx
@@ -1,0 +1,16 @@
+import { useViewport } from '../contexts/ViewportContext';
+
+export default function TabletSwitch() {
+  const { forceTablet, toggleForceTablet } = useViewport();
+  return (
+    <label className="flex items-center gap-2 cursor-pointer">
+      <input
+        type="checkbox"
+        checked={forceTablet}
+        onChange={toggleForceTablet}
+        className="rounded"
+      />
+      <span className="text-sm">Tablet layout</span>
+    </label>
+  );
+}

--- a/frontend/src/contexts/ViewportContext.tsx
+++ b/frontend/src/contexts/ViewportContext.tsx
@@ -1,0 +1,47 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+
+interface ViewportContextValue {
+  forceTablet: boolean;
+  toggleForceTablet: () => void;
+}
+
+const ViewportContext = createContext<ViewportContextValue | undefined>(undefined);
+
+export function ViewportProvider({ children }: { children: ReactNode }) {
+  const [forceTablet, setForceTablet] = useState(() => {
+    const stored = localStorage.getItem("forceTablet");
+    return stored === "true";
+  });
+
+  useEffect(() => {
+    const meta = document.querySelector<HTMLMetaElement>("meta[name=viewport]");
+    if (!meta) return;
+    if (forceTablet) {
+      meta.setAttribute("content", "width=768");
+    } else {
+      meta.setAttribute("content", "width=device-width, initial-scale=1.0");
+    }
+  }, [forceTablet]);
+
+  const toggleForceTablet = () => {
+    setForceTablet((prev) => {
+      const next = !prev;
+      localStorage.setItem("forceTablet", String(next));
+      return next;
+    });
+  };
+
+  return (
+    <ViewportContext.Provider value={{ forceTablet, toggleForceTablet }}>
+      {children}
+    </ViewportContext.Provider>
+  );
+}
+
+export function useViewport() {
+  const ctx = useContext(ViewportContext);
+  if (!ctx) throw new Error("useViewport must be used within ViewportProvider");
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
+import { ViewportProvider } from './contexts/ViewportContext';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ViewportProvider>
+      <App />
+    </ViewportProvider>
   </StrictMode>,
-)
+);

--- a/frontend/src/pages/FindRecipes.tsx
+++ b/frontend/src/pages/FindRecipes.tsx
@@ -39,8 +39,10 @@ export default function FindRecipes() {
   };
 
   useEffect(() => {
-    listTags().then((t) => setTags(t.map((x) => (typeof x === "string" ? x : x.name))));
-    listCategories().then((c) =>
+    listTags().then((t: Array<string | { name: string }>) =>
+      setTags(t.map((x) => (typeof x === "string" ? x : x.name)))
+    );
+    listCategories().then((c: Array<string | { name: string }>) =>
       setCategories(c.map((x) => (typeof x === "string" ? x : x.name)))
     );
   }, []);

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -1,5 +1,5 @@
 // Recipes.tsx - Page for searching, saving, and viewing cocktail recipes
-import React, { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { listRecipes, searchRecipes, createRecipe } from '../api';
 import { Link } from 'react-router-dom';
 import { Search } from 'lucide-react';


### PR DESCRIPTION
## Summary
- add ViewportProvider context and TabletSwitch component
- allow user to force tablet layout by updating meta viewport
- expose tablet layout toggle in Navbar drawer
- fix lint and TypeScript issues from new code

## Testing
- `pytest -q`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877e422f6b08330bc30ddbb583e2346