### PR TITLE
Add button for force tablet mode

### DIFF
--- a/frontend/src/components/ForceTabletButton.tsx
+++ b/frontend/src/components/ForceTabletButton.tsx
@@ -1,0 +1,13 @@
+import { useViewport } from '../contexts/ViewportContext';
+
+export default function ForceTabletButton() {
+  const { forceTablet, toggleForceTablet } = useViewport();
+  return (
+    <button
+      onClick={() => !forceTablet && toggleForceTablet()}
+      className="button-send"
+    >
+      Force Tablet
+    </button>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -3,6 +3,7 @@ import { Menu, X } from "lucide-react";
 import { useState } from "react";
 import Drawer from "./Drawer";
 import TabletSwitch from "./TabletSwitch";
+import ForceTabletButton from "./ForceTabletButton";
 
 
 
@@ -57,8 +58,9 @@ export default function Navbar() {
         >
           <Menu size={20} />
         </button>
-        <div className="hidden md:flex gap-4 md:gap-6">
+        <div className="hidden md:flex gap-4 md:gap-6 items-center">
           <Links />
+          <ForceTabletButton />
         </div>
       </nav>
       <Drawer open={open} onClose={() => setOpen(false)}>
@@ -70,6 +72,7 @@ export default function Navbar() {
             <Links />
           </nav>
           <TabletSwitch />
+          <ForceTabletButton />
         </div>
       </Drawer>
     </header>


### PR DESCRIPTION
## Summary
- add `ForceTabletButton` component
- show `ForceTabletButton` in the navbar and mobile drawer

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877e7e095d08330b6ea65d8a02a6160