### PR TITLE
Fix mobile search result description layout

### DIFF
--- a/frontend/src/components/RecipeList.tsx
+++ b/frontend/src/components/RecipeList.tsx
@@ -117,7 +117,7 @@ export default function RecipeList({
               </div>
               {expandedKey && (
                 <div
-                  className="grid grid-cols-4 gap-4 h-52 w-full p-2 text-sm text-[var(--text-muted)] mb-4"
+                  className="grid grid-cols-1 w-full gap-4 p-2 text-sm text-[var(--text-muted)] mb-4 md:grid-cols-4 md:h-52"
                   // style={{ gridTemplateColumns: '1fr 1fr 2fr 1fr' }}
                 >
                   {/* Image */}


### PR DESCRIPTION
## Summary
- adjust RecipeList details grid to use one column on small screens
- preserve 4-column layout with fixed height only on medium screens and up

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879f6a3823c8330a74ab8262dd29c29