### PR TITLE
Add unit conversion helper

### DIFF
--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
-from ..services import synonyms, unit_synonyms
+from ..services import synonyms, unit_synonyms, unit_conversion
 from . import models, schemas
 
 
@@ -142,11 +142,12 @@ def get_recipe_with_inventory(db: Session, recipe_id: int):
         canonical = synonyms.canonical_name(r_ing.name)
         ing = get_or_create_ingredient(db, schemas.IngredientCreate(name=canonical))
         item = get_inventory_by_ingredient(db, ing.id)
+        measure = unit_conversion.with_metric(r_ing.measure)
         ingredients.append(
             schemas.RecipeIngredientWithInventory(
                 id=r_ing.id,
                 name=r_ing.name,
-                measure=r_ing.measure,
+                measure=measure,
                 inventory_item_id=item.id if item else None,
                 inventory_quantity=item.quantity if item else 0,
             )

--- a/backend/app/services/unit_conversion.py
+++ b/backend/app/services/unit_conversion.py
@@ -1,0 +1,88 @@
+"""Convert common US/imperial units to metric."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+
+from .unit_synonyms import canonical_name
+
+# Conversion factors to milliliters for canonical units
+CONVERSION_TO_ML: dict[str, float] = {
+    "ml": 1.0,
+    "cl": 10.0,
+    "l": 1000.0,
+    "tsp": 5.0,
+    "tbsp": 15.0,
+    "oz": 30.0,
+    "jigger": 45.0,
+    "shot": 44.0,
+    "cup": 240.0,
+    "pt": 475.0,
+    "qt": 946.0,
+    "gal": 3785.0,
+}
+
+
+def _parse_measure(measure: str | None) -> tuple[float, str] | None:
+    """Return numeric amount and canonical unit from a measure string."""
+    if not measure:
+        return None
+    parts = measure.strip().split()
+    if not parts:
+        return None
+    qty = 0.0
+    idx = 0
+    # allow quantities like "1 1/2" or "1/2"
+    while idx < len(parts):
+        try:
+            qty += float(Fraction(parts[idx]))
+            idx += 1
+        except (ValueError, ZeroDivisionError):
+            break
+    if idx >= len(parts):
+        return None
+    unit = " ".join(parts[idx:]).strip()
+    if not unit:
+        return None
+    unit = canonical_name(unit)
+    return qty, unit
+
+
+def to_metric(measure: str | None) -> str | None:
+    """Return a metric representation of a measure string.
+
+    Examples:
+        >>> to_metric("2 oz")
+        '60 ml'
+    """
+    parsed = _parse_measure(measure)
+    if not parsed:
+        return None
+    qty, unit = parsed
+    factor = CONVERSION_TO_ML.get(unit)
+    if factor is None:
+        return None
+    ml_value = qty * factor
+    if ml_value >= 1000:
+        liters = ml_value / 1000
+        if liters.is_integer():
+            return f"{int(liters)} l"
+        return f"{liters:.1f} l"
+    if ml_value.is_integer():
+        return f"{int(ml_value)} ml"
+    return f"{ml_value:.1f} ml"
+
+
+def with_metric(measure: str | None) -> str | None:
+    """Return measure with metric equivalent appended if needed."""
+    parsed = _parse_measure(measure)
+    if not parsed:
+        return measure
+    _, unit = parsed
+    if unit in {"ml", "cl", "l"}:
+        return measure
+    metric = to_metric(measure)
+    if metric:
+        return f"{measure} ({metric})"
+    return measure
+

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -127,6 +127,7 @@ async def test_get_recipe(monkeypatch, async_client):
     assert data["glass"]["name"] == "Highball glass"
     assert data["alcoholic"]["name"] == "Alcoholic"
     ing = next(i for i in data["ingredients"] if i["name"] == "Rum")
+    assert ing["measure"] == "2 oz (60 ml)"
     assert ing["inventory_quantity"] == 0
     assert ing["inventory_item_id"] is not None
 

--- a/backend/tests/test_unit_conversion.py
+++ b/backend/tests/test_unit_conversion.py
@@ -1,0 +1,33 @@
+import pytest
+
+from backend.app.services.unit_conversion import to_metric, with_metric
+
+
+@pytest.mark.parametrize(
+    "measure,expected",
+    [
+        ("2 oz", "60 ml"),
+        ("1 oz", "30 ml"),
+        ("1/2 oz", "15 ml"),
+        ("1 1/2 oz", "45 ml"),
+        ("3 tsp", "15 ml"),
+    ],
+)
+def test_to_metric(measure, expected):
+    assert to_metric(measure) == expected
+
+
+def test_to_metric_unknown():
+    assert to_metric("2 parts") is None
+
+
+@pytest.mark.parametrize(
+    "measure,expected",
+    [
+        ("2 oz", "2 oz (60 ml)"),
+        ("3 tsp", "3 tsp (15 ml)"),
+        ("30 ml", "30 ml"),
+    ],
+)
+def test_with_metric(measure, expected):
+    assert with_metric(measure) == expected


### PR DESCRIPTION
## Summary
- implement a small `unit_conversion` service for converting imperial units to metric
- add tests for the new conversion helper
- show metric measure in recipe output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a16fa75188330b9c538452ff44bff