### PR TITLE
Update inventory and synonyms styles

### DIFF
--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -224,35 +224,33 @@ export default function Inventory() {
           Aggregate Synonyms
         </button>
       </div>
-      <table className="min-w-full border border-[var(--border)] text-left">
-        <thead>
-          <tr>
-            <th className="px-2">Name</th>
-            <th className="px-2">Qty</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
+      <div className="card p-0">
+        <div className="flex items-center px-4 py-2 font-semibold">
+          <span className="flex-1">Name</span>
+          <span className="w-20">Qty</span>
+        </div>
+        <ul className="divide-y divide-[var(--border)]">
           {items.map((it) => (
-            <tr key={it.id} className="border-t border-[var(--border)]">
-              <td className="px-2 py-1">{it.ingredient?.name || it.ingredient_id}</td>
-              <td className="px-2 py-1">
-                <input
-                  type="number"
-                  value={it.quantity}
-                  onChange={(e) => updateQty(it.id, parseInt(e.target.value))}
-                  className="w-16 border border-[var(--border)]"
-                />
-              </td>
-              <td className="px-2 py-1">
-                <button onClick={() => remove(it.id)} className="button-search">
-                  Delete
-                </button>
-              </td>
-            </tr>
+            <li
+              key={it.id}
+              className="flex items-center px-4 py-2 gap-4 justify-between"
+            >
+              <span className="flex-1">
+                {it.ingredient?.name || it.ingredient_id}
+              </span>
+              <input
+                type="number"
+                value={it.quantity}
+                onChange={(e) => updateQty(it.id, parseInt(e.target.value))}
+                className="w-16 border border-[var(--border)] bg-transparent"
+              />
+              <button onClick={() => remove(it.id)} className="button-search">
+                Delete
+              </button>
+            </li>
           ))}
-        </tbody>
-      </table>
+        </ul>
+      </div>
       {debugLog.length > 0 && (
         <div className="mt-4 space-y-2">
           <button

--- a/frontend/src/pages/Synonyms.tsx
+++ b/frontend/src/pages/Synonyms.tsx
@@ -152,28 +152,21 @@ export default function Synonyms() {
           </button>
         </div>
       )}
-      <table className="min-w-full border text-left" style={{ border: '1px solid var(--border)' }}>
-        <thead>
-          <tr>
-            <th className="px-2">Alias</th>
-            <th className="px-2">Canonical</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
+      <div className="card p-0">
+        <div className="flex items-center px-4 py-2 font-semibold">
+          <span className="flex-1">Alias</span>
+          <span className="w-32">Canonical</span>
+        </div>
+        <ul className="divide-y divide-[var(--border)]">
           {synonyms.map((s) => (
-            <tr key={s.alias} className="border-t" style={{ borderTop: '1px solid var(--border)' }}>
-              <td className="px-2 py-1">{s.alias}</td>
-              <td className="px-2 py-1">{s.canonical}</td>
-              <td className="px-2 py-1">
-                <button onClick={() => remove(s.alias)} className="button-search">
-                  Delete
-                </button>
-              </td>
-            </tr>
+            <li key={s.alias} className="flex items-center px-4 py-2 gap-4 justify-between">
+              <span className="flex-1">{s.alias}</span>
+              <span className="w-32">{s.canonical}</span>
+              <button onClick={() => remove(s.alias)} className="button-search">Delete</button>
+            </li>
           ))}
-        </tbody>
-      </table>
+        </ul>
+      </div>
 
       <h1 className="text-xl font-bold">Unit Synonyms</h1>
       <div className="space-x-2">
@@ -215,28 +208,21 @@ export default function Synonyms() {
           </button>
         </div>
       )}
-      <table className="min-w-full border text-left" style={{ border: '1px solid var(--border)' }}>
-        <thead>
-          <tr>
-            <th className="px-2">Alias</th>
-            <th className="px-2">Canonical</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
+      <div className="card p-0">
+        <div className="flex items-center px-4 py-2 font-semibold">
+          <span className="flex-1">Alias</span>
+          <span className="w-32">Canonical</span>
+        </div>
+        <ul className="divide-y divide-[var(--border)]">
           {unitSynonyms.map((s) => (
-            <tr key={s.alias} className="border-t" style={{ borderTop: '1px solid var(--border)' }}>
-              <td className="px-2 py-1">{s.alias}</td>
-              <td className="px-2 py-1">{s.canonical}</td>
-              <td className="px-2 py-1">
-                <button onClick={() => removeUnit(s.alias)} className="button-search">
-                  Delete
-                </button>
-              </td>
-            </tr>
+            <li key={s.alias} className="flex items-center px-4 py-2 gap-4 justify-between">
+              <span className="flex-1">{s.alias}</span>
+              <span className="w-32">{s.canonical}</span>
+              <button onClick={() => removeUnit(s.alias)} className="button-search">Delete</button>
+            </li>
           ))}
-        </tbody>
-      </table>
+        </ul>
+      </div>
         {debugLog.length > 0 && (
         <div className="mt-4 space-y-2">
           <button


### PR DESCRIPTION
## Summary
- modernize inventory list design to match RecipeList
- restyle synonyms pages lists using card layouts

## Testing
- `npm run lint`
- `npm run build` *(fails: Parameter 'text' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_687a2d1554408330912de17f4abd1716