### PR TITLE
Improve dashboard layout and link home

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
 import Inventory from "./pages/Inventory";
@@ -8,25 +7,15 @@ import RecipeDetail from "./pages/RecipeDetail";
 import ShoppingList from "./pages/ShoppingList";
 import Stats from "./pages/Stats";
 import Synonyms from "./pages/Synonyms";
-import { healthCheck } from "./api";
 import Navbar from "./components/Navbar";
 import "./App.css";
 
 export default function App() {
-  const [health, setHealth] = useState<string | null>(null);
-  useEffect(() => {
-    healthCheck()
-      .then((res) => setHealth(res.status))
-      .catch(() => setHealth("error"));
-  }, []);
 
   return (
     <Router>
       <Navbar />
       <main className="mx-auto max-w-screen-xl px-4 md:px-6 py-4">
-        {health && (
-          <div className="mb-4 text-sm text-gray-500">Health: {health}</div>
-        )}
         <Routes>
           <Route path="/" element={<Dashboard />} />
           <Route path="/inventory" element={<Inventory />} />

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -18,7 +18,7 @@ export default function BarcodeScanner({ onDetected }: { onDetected: (code: stri
     )
 
     scanner.render(
-      (text) => {
+      (text: string) => {
         onDetected(text)
         scanner.clear().catch(() => {})
       },

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -48,7 +48,12 @@ export default function Navbar() {
     <header className="bg-[var(--bg-elevated)] border-b border-[var(--border)] text-[var(--text-primary)] shadow-lg sticky top-0 z-50 rounded-[var(--brand-radius)]">
       <nav className="max-w-screen-xl mx-auto flex items-center justify-between py-3 px-4 md:px-6">
         <div className="flex items-center gap-3">
-          <span className="text-3xl font-bold tracking-tight text-[var(--accent)]">Bartool</span>
+          <NavLink
+            to="/"
+            className="text-3xl font-bold tracking-tight text-[var(--accent)]"
+          >
+            Bartool
+          </NavLink>
         </div>
         <button
           className="md:hidden p-2 hover:bg-[var(--bg-primary)] rounded-[var(--brand-radius)]"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -9,10 +9,16 @@ import {
   Download,
   Upload,
 } from 'lucide-react';
-import { exportDatabase, importDatabase } from '../api';
-import { useRef } from 'react';
+import { exportDatabase, importDatabase, healthCheck } from '../api';
+import { useRef, useEffect, useState } from 'react';
 
 export default function Dashboard() {
+  const [health, setHealth] = useState<string | null>(null);
+  useEffect(() => {
+    healthCheck()
+      .then((res) => setHealth(res.status))
+      .catch(() => setHealth('error'));
+  }, []);
   const features = [
     { to: '/inventory', title: 'Inventory', icon: <Box size={20} /> },
     { to: '/recipes', title: 'Recipes', icon: <BookOpen size={20} /> },
@@ -49,7 +55,10 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold font-display">Dashboard</h1>
+      <h1 className="text-4xl font-bold font-display">Dashboard</h1>
+      {health && (
+        <div className="text-sm text-gray-500">Health: {health}</div>
+      )}
       <p className="text-[var(--text-muted)]">Welcome to BarTool. Select an action below.</p>
       <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-4">
         {features.map((f) => (

--- a/frontend/src/pages/FindRecipes.tsx
+++ b/frontend/src/pages/FindRecipes.tsx
@@ -65,8 +65,8 @@ export default function FindRecipes() {
   }, [searchParams]);
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-3xl font-bold font-display">Recipe Finder</h1>
+    <div className="space-y-6">
+      <h1 className="text-4xl font-bold font-display">Recipe Finder</h1>
       <div className="flex max-w-md items-center overflow-hidden rounded border border-[var(--border)]">
         <input
           value={query}

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -146,8 +146,8 @@ export default function Inventory() {
   }
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-3xl font-bold font-display">Inventory</h1>
+    <div className="space-y-6">
+      <h1 className="text-4xl font-bold font-display">Inventory</h1>
 
       <section className="space-y-4 p-4 mb-6 rounded-lg shadow">
         <h2 className="text-xl font-semibold">Barcode Lookup</h2>

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -56,7 +56,7 @@ export default function RecipeDetail() {
   }
 
   return (
-    <div className="space-y-4 text-white">
+    <div className="space-y-6 text-white">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
         {recipe.thumb && (
           <img
@@ -66,7 +66,7 @@ export default function RecipeDetail() {
           />
         )}
         <div>
-          <h1 className="text-3xl font-bold mb-2 font-display">{recipe.name}</h1>
+          <h1 className="text-4xl font-bold mb-2 font-display">{recipe.name}</h1>
           {(recipe.categories?.length || recipe.tags?.length || recipe.ibas?.length) && (
             <div className="space-y-1 mb-2 text-sm text-[var(--text-secondary)]">
               {recipe.categories && recipe.categories.length > 0 && (

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -44,9 +44,9 @@ export default function Recipes() {
   };
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       {/* Page title */}
-      <h1 className="text-3xl font-bold font-display">Recipes</h1>
+      <h1 className="text-4xl font-bold font-display">Recipes</h1>
       {/* Search bar */}
       <div className="flex max-w-md items-center overflow-hidden rounded border border-[var(--border)]">
         <input

--- a/frontend/src/pages/ShoppingList.tsx
+++ b/frontend/src/pages/ShoppingList.tsx
@@ -89,7 +89,7 @@ export default function ShoppingList() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-display text-3xl font-semibold">Shopping List</h1>
+      <h1 className="font-display text-4xl font-semibold">Shopping List</h1>
       <div className="flex gap-4">
         <button onClick={download} className="button-search">
           Download

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,7 +1,7 @@
 export default function Stats() {
   return (
-    <div className="space-y-4">
-      <h1 className="text-3xl font-bold font-display">Stats</h1>
+    <div className="space-y-6">
+      <h1 className="text-4xl font-bold font-display">Stats</h1>
       <p className="text-gray-700">View statistics about your inventory usage.</p>
     </div>
   );

--- a/frontend/src/pages/Synonyms.tsx
+++ b/frontend/src/pages/Synonyms.tsx
@@ -111,8 +111,8 @@ export default function Synonyms() {
   };
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-3xl font-bold font-display">Synonyms</h1>
+    <div className="space-y-6">
+      <h1 className="text-4xl font-bold font-display">Synonyms</h1>
       <div className="space-x-2">
         <input
           placeholder="Alias"


### PR DESCRIPTION
## Summary
- enlarge page headers and spacing
- show health status only on the dashboard
- link the brand name in navbar to the dashboard
- fix TypeScript build issue

## Testing
- `npm run lint`
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a2fd282b0833086c8d083b20e7e9c