### PR TITLE
Add cocktail suggestions slider

### DIFF
--- a/backend/app/api/suggestions.py
+++ b/backend/app/api/suggestions.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..db import crud, schemas, session
+
+router = APIRouter()
+
+@router.get("", response_model=list[schemas.RecipeWithInventory])
+def get_suggestions(
+    limit: int = 3,
+    max_missing: int | None = None,
+    db: Session = Depends(session.get_db),
+):
+    """Return random recipe suggestions with few missing ingredients."""
+    return crud.suggest_recipes(db, limit=limit, max_missing=max_missing)
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,7 @@ from .api import (
     synonyms,
     unit_synonyms,
     shopping_list,
+    suggestions,
     db_admin,
 )
 
@@ -59,4 +60,5 @@ app.include_router(synonyms.router, prefix="/synonyms")
 app.include_router(unit_synonyms.router, prefix="/unit-synonyms")
 app.include_router(shopping_list.router, prefix="/shopping-list")
 app.include_router(db_admin.router, prefix="/db")
+app.include_router(suggestions.router, prefix="/suggestions")
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -212,6 +212,15 @@ export async function findRecipes(options: FindRecipesOptions = {}) {
   return res.json();
 }
 
+export async function getSuggestions(limit = 3, max_missing?: number) {
+  const params = new URLSearchParams();
+  if (limit !== undefined) params.append('limit', String(limit));
+  if (max_missing !== undefined) params.append('max_missing', String(max_missing));
+  const query = params.toString();
+  const res = await fetch(`${API_BASE}/suggestions${query ? `?${query}` : ''}`);
+  return res.json();
+}
+
 export async function getRecipe(id: number): Promise<RecipeDetail> {
   const res = await fetch(`${API_BASE}/recipes/${id}`);
   if (!res.ok) {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -9,15 +9,18 @@ import {
   Download,
   Upload,
 } from 'lucide-react';
-import { exportDatabase, importDatabase, healthCheck } from '../api';
+import { exportDatabase, importDatabase, healthCheck, getSuggestions } from '../api';
 import { useRef, useEffect, useState } from 'react';
+import type { RecipeItem } from '../components/RecipeList';
 
 export default function Dashboard() {
   const [health, setHealth] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<RecipeItem[]>([]);
   useEffect(() => {
     healthCheck()
       .then((res) => setHealth(res.status))
       .catch(() => setHealth('error'));
+    getSuggestions(3).then(setSuggestions).catch(() => setSuggestions([]));
   }, []);
   const features = [
     { to: '/inventory', title: 'Inventory', icon: <Box size={20} /> },
@@ -85,6 +88,26 @@ export default function Dashboard() {
           )
         ))}
       </div>
+      {suggestions.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold">Suggestions</h2>
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {suggestions.map((s, idx) => (
+              <div key={s.id ?? idx} className="min-w-[10rem] card p-2 flex-shrink-0">
+                {s.thumb && (
+                  <img src={s.thumb} alt={s.name} className="h-24 w-full object-cover rounded" />
+                )}
+                <div className="font-semibold text-center mt-2">{s.name}</div>
+                {typeof s.missing_count === 'number' && (
+                  <div className="text-sm text-[var(--text-muted)] text-center">
+                    Missing {s.missing_count}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
       <input
         type="file"
         ref={fileRef}

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -65,6 +65,18 @@ paths:
           name: limit
           schema:
             type: integer
+  /suggestions:
+    get:
+      summary: Suggest random recipes prioritising available ones
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+        - in: query
+          name: max_missing
+          schema:
+            type: integer
   /recipes:
     get:
       summary: List recipes


### PR DESCRIPTION
## Summary
- implement suggestion algorithm and API endpoint
- expose `/suggestions` in OpenAPI
- fetch random suggestions on dashboard and show slider
- add API client helper for suggestions
- test the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a33951aa483308d75f6dc5b3917dd