### PR TITLE
Fix barcode scanner not triggering

### DIFF
--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -11,7 +11,12 @@ export default function BarcodeScanner({ onDetected }: { onDetected: (code: stri
       {
         fps: 10,
         qrbox: { width: 300, height: 150 },
-        formatsToSupport: [Html5QrcodeSupportedFormats.EAN_13],
+        formatsToSupport: [
+          Html5QrcodeSupportedFormats.EAN_13,
+          Html5QrcodeSupportedFormats.EAN_8,
+          Html5QrcodeSupportedFormats.UPC_A,
+          Html5QrcodeSupportedFormats.UPC_E,
+        ],
         useBarCodeDetectorIfSupported: true
       },
       false


### PR DESCRIPTION
## Summary
- expand barcode formats to recognize EAN-8 and UPC codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a78371068833088d358e820856135