### PR TITLE
Fix suggestion page inventory loading

### DIFF
--- a/frontend/src/pages/Suggestions.tsx
+++ b/frontend/src/pages/Suggestions.tsx
@@ -11,9 +11,9 @@ export default function SuggestionsPage() {
   const [drag, setDrag] = useState<number | null>(null);
 
   useEffect(() => {
-    listInventory().then((res) => {
-      if (Array.isArray(res)) {
-        setItems(res);
+    listInventory().then(({ data }) => {
+      if (Array.isArray(data)) {
+        setItems(data);
       } else {
         setItems([]);
       }


### PR DESCRIPTION
## Summary
- fix suggestions page so the inventory list populates correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a92f8fe588330ad815e2dd78de794