### PR TITLE
Make suggestions filter optional

### DIFF
--- a/frontend/src/pages/Suggestions.tsx
+++ b/frontend/src/pages/Suggestions.tsx
@@ -21,15 +21,13 @@ export default function SuggestionsPage() {
   }, []);
 
   useEffect(() => {
-    if (selected.length === 0) {
-      setRecipes([]);
-      return;
-    }
     getSuggestionsByIngredients({
       ingredients: selected,
       mode,
       max_missing: maxMissing === 3 ? undefined : maxMissing,
-    }).then(setRecipes);
+    })
+      .then(setRecipes)
+      .catch(() => setRecipes([]));
   }, [selected, mode, maxMissing]);
 
   const toggle = (id: number) => {


### PR DESCRIPTION
## Summary
- allow calling suggestions API without choosing ingredients

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687a95454b38833082c8532ec8f5c3e4