### PR TITLE
Add recipe delete feature

### DIFF
--- a/backend/app/api/recipes.py
+++ b/backend/app/api/recipes.py
@@ -37,3 +37,11 @@ async def create_recipe(recipe: schemas.RecipeCreate, db: Session = Depends(sess
     db_recipe = crud.create_recipe(db, recipe)
     crud.ensure_inventory_for_ingredients(db, recipe.ingredients)
     return db_recipe
+
+
+@router.delete("/{recipe_id}", status_code=204)
+def delete_recipe(recipe_id: int, db: Session = Depends(session.get_db)):
+    success = crud.delete_recipe(db, recipe_id)
+    if not success:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    return None

--- a/backend/app/db/crud.py
+++ b/backend/app/db/crud.py
@@ -205,6 +205,15 @@ def list_recipes(db: Session, skip: int = 0, limit: int = 100):
     return db.query(models.Recipe).offset(skip).limit(limit).all()
 
 
+def delete_recipe(db: Session, recipe_id: int) -> bool:
+    recipe = get_recipe(db, recipe_id)
+    if not recipe:
+        return False
+    db.delete(recipe)
+    db.commit()
+    return True
+
+
 # InventoryItem CRUD
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -133,6 +133,37 @@ async def test_get_recipe(monkeypatch, async_client):
 
 
 @pytest.mark.asyncio
+async def test_recipe_delete(monkeypatch, async_client):
+    async def fake_fetch(name: str):
+        return {
+            "name": "Delete Drink",
+            "alcoholic": "Alcoholic",
+            "glass": None,
+            "instructions": "Mix",
+            "thumb": None,
+            "tags": [],
+            "categories": [],
+            "ibas": [],
+            "ingredients": [],
+        }
+
+    monkeypatch.setattr(
+        "backend.app.services.cocktaildb.fetch_recipe_details", fake_fetch
+    )
+    monkeypatch.setattr("backend.app.api.recipes.fetch_recipe_details", fake_fetch)
+
+    resp = await async_client.post("/recipes/", json={"name": "delete drink"})
+    assert resp.status_code == 201
+    recipe_id = resp.json()["id"]
+
+    resp = await async_client.delete(f"/recipes/{recipe_id}")
+    assert resp.status_code == 204
+
+    resp = await async_client.get(f"/recipes/{recipe_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_recipe_search(monkeypatch, async_client):
     async def fake_search(name: str):
         return [

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -280,6 +280,13 @@ export async function createRecipe(data: { name: string }) {
   return res.json();
 }
 
+export async function deleteRecipe(id: number) {
+  const res = await fetch(`${API_BASE}/recipes/${id}`, { method: "DELETE" });
+  if (!res.ok) {
+    throw new Error("Delete failed");
+  }
+}
+
 export async function listSynonyms() {
   return fetchJson<Synonym[]>(`${API_BASE}/synonyms/`);
 }

--- a/frontend/src/pages/FindRecipes.tsx
+++ b/frontend/src/pages/FindRecipes.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { findRecipes, listTags, listCategories } from "../api";
+import { findRecipes, listTags, listCategories, deleteRecipe } from "../api";
 import { Link, useSearchParams } from "react-router-dom";
 import { Search } from "lucide-react";
 import RecipeList, { type RecipeItem } from "../components/RecipeList";
@@ -37,6 +37,11 @@ export default function FindRecipes() {
       order_missing: orderMissing,
     });
     setResults(data);
+  };
+
+  const remove = async (id: number) => {
+    await deleteRecipe(id);
+    runSearch();
   };
 
   useEffect(() => {
@@ -215,11 +220,18 @@ export default function FindRecipes() {
         <RecipeList
           recipes={results}
           showCounts
-          renderAction={(r) => (
-            <Link to={`/recipes/${r.id}`} className="button-search">
-              Open
-            </Link>
-          )}
+          renderAction={(r) =>
+            r.id ? (
+              <span className="flex gap-2">
+                <Link to={`/recipes/${r.id}`} className="button-search">
+                  Open
+                </Link>
+                <button onClick={() => remove(r.id!)} className="button-search">
+                  Delete
+                </button>
+              </span>
+            ) : null
+          }
         />
       )}
     </div>

--- a/frontend/src/pages/RecipeDetail.tsx
+++ b/frontend/src/pages/RecipeDetail.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import {
   getRecipe,
   addMissingFromRecipe,
   updateInventory,
+  deleteRecipe,
   listSynonyms,
   type RecipeDetail,
   type RecipeIngredient,
@@ -13,6 +14,7 @@ import {
 
 export default function RecipeDetail() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const [recipe, setRecipe] = useState<RecipeDetail | null>(null);
   const [added, setAdded] = useState<number | null>(null);
   const [synonyms, setSynonyms] = useState<Synonym[]>([]);
@@ -140,6 +142,17 @@ export default function RecipeDetail() {
                 : "All ingredients already in inventory"}
             </p>
           )}
+          <button
+            onClick={async () => {
+              if (recipe) {
+                await deleteRecipe(recipe.id);
+                navigate('/search');
+              }
+            }}
+            className="button-search mt-4"
+          >
+            Delete recipe
+          </button>
         </div>
       </div>
       {recipe.ingredients && recipe.ingredients.length > 0 && (

--- a/openapi_paths.yaml
+++ b/openapi_paths.yaml
@@ -142,6 +142,14 @@ paths:
           required: true
           schema:
             type: integer
+    delete:
+      summary: Delete recipe
+      parameters:
+        - in: path
+          name: recipe_id
+          required: true
+          schema:
+            type: integer
   /inventory/{id}:
     get:
       summary: Get inventory item


### PR DESCRIPTION
## Summary
- allow deleting recipes on the backend
- expose recipe delete endpoint in the API spec
- add deleteRecipe helper in the frontend API
- add delete button to recipe detail page
- add delete button in Recipe Library list
- test recipe deletion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa51d184c8330b30c70f93908f7b7