### PR TITLE
Improve heading styles

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -57,3 +57,7 @@ body {
 .chip-hover:hover {
   background-color: color-mix(in srgb, var(--accent) 10%, transparent);
 }
+
+.page-title {
+  @apply text-5xl font-bold font-display text-center my-8;
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -56,7 +56,7 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-4xl font-bold font-display">Dashboard</h1>
+      <h1 className="page-title">Dashboard</h1>
       {health && (
         <div className="text-sm text-gray-500">Health: {health}</div>
       )}

--- a/frontend/src/pages/FindRecipes.tsx
+++ b/frontend/src/pages/FindRecipes.tsx
@@ -72,7 +72,7 @@ export default function FindRecipes() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-4xl font-bold font-display">Recipe Library</h1>
+      <h1 className="page-title">Recipe Library</h1>
       <Suggestions limit={4} />
       <div className="flex max-w-md items-center overflow-hidden rounded border border-[var(--border)]">
         <input

--- a/frontend/src/pages/Inventory.tsx
+++ b/frontend/src/pages/Inventory.tsx
@@ -147,7 +147,7 @@ export default function Inventory() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-4xl font-bold font-display">Inventory</h1>
+      <h1 className="page-title">Inventory</h1>
 
       <section className="card p-4">
         <h2 className="text-xl font-semibold mb-4">Barcode Lookup</h2>

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -46,7 +46,7 @@ export default function Recipes() {
   return (
     <div className="space-y-6">
       {/* Page title */}
-      <h1 className="text-4xl font-bold font-display">New Recipes</h1>
+      <h1 className="page-title">New Recipes</h1>
       {/* Search bar */}
       <div className="flex max-w-md items-center overflow-hidden rounded border border-[var(--border)]">
         <input

--- a/frontend/src/pages/ShoppingList.tsx
+++ b/frontend/src/pages/ShoppingList.tsx
@@ -89,7 +89,7 @@ export default function ShoppingList() {
 
   return (
     <div className="space-y-6">
-      <h1 className="font-display text-4xl font-semibold">Shopping List</h1>
+      <h1 className="page-title">Shopping List</h1>
       <div className="flex gap-4">
         <button onClick={download} className="button-search">
           Download

--- a/frontend/src/pages/Stats.tsx
+++ b/frontend/src/pages/Stats.tsx
@@ -1,7 +1,7 @@
 export default function Stats() {
   return (
     <div className="space-y-6">
-      <h1 className="text-4xl font-bold font-display">Stats</h1>
+      <h1 className="page-title">Stats</h1>
       <p className="text-gray-700">View statistics about your inventory usage.</p>
     </div>
   );

--- a/frontend/src/pages/Suggestions.tsx
+++ b/frontend/src/pages/Suggestions.tsx
@@ -86,7 +86,7 @@ export default function SuggestionsPage() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-4xl font-bold font-display mb-8">Suggestions</h1>
+      <h1 className="page-title mb-8">Suggestions</h1>
 
       {/* Ingredients Section */}
       <section className="card p-0">

--- a/frontend/src/pages/Synonyms.tsx
+++ b/frontend/src/pages/Synonyms.tsx
@@ -112,7 +112,7 @@ export default function Synonyms() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-4xl font-bold font-display">Synonyms</h1>
+      <h1 className="page-title">Synonyms</h1>
       <div className="space-x-2">
         <input
           placeholder="Alias"


### PR DESCRIPTION
## Summary
- add `.page-title` utility style
- enlarge and center page titles

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_687bdd3cacd883308c4c2a20791c2150