### PR TITLE
Add responsive mobile layout for recipe list

### DIFF
--- a/frontend/src/components/RecipeList.tsx
+++ b/frontend/src/components/RecipeList.tsx
@@ -69,7 +69,7 @@ export default function RecipeList({
           return (
             <li key={key}>
               <div
-                className="flex items-center gap-2 p-4 cursor-pointer mb-[5px] mt-[5px] bg-[var(--bg-elevated-dark)]"
+                className="flex flex-col md:flex-row items-start md:items-center gap-2 p-4 cursor-pointer mb-[5px] mt-[5px] bg-[var(--bg-elevated-dark)]"
                 onClick={() => setExpanded(expandedKey ? null : key)}
               >
                 <span className="flex-1 truncate font-semibold flex items-center gap-2">
@@ -107,20 +107,25 @@ export default function RecipeList({
                 {showCounts &&
                   typeof r.available_count === 'number' &&
                   typeof r.missing_count === 'number' && (
-                    <span className="text-sm text-[var(--text-secondary)] mr-8">
+                    <span className="text-sm text-[var(--text-secondary)] md:mr-8 mt-2 md:mt-0">
                       {r.available_count} available / {r.missing_count} missing
                     </span>
                   )}
                 {renderAction && (
-                  <span onClick={(e) => e.stopPropagation()}>{renderAction(r)}</span>
+                  <span
+                    className="mt-2 md:mt-0"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {renderAction(r)}
+                  </span>
                 )}
               </div>
               {expandedKey && (
                 <div
-                  className="grid grid-cols-3 gap-4 h-52 w-full p-2 text-sm text-[var(--text-muted)] mb-8 mt-6"
+                  className="grid grid-cols-1 md:grid-cols-3 gap-4 md:h-52 w-full p-2 text-sm text-[var(--text-muted)] mb-8 mt-6"
                 >
                   {/* Image */}
-                  <div className="flex  justify-center">
+                  <div className="flex justify-center">
                     {r.thumb && (
                       <img
                         src={r.thumb}
@@ -130,7 +135,7 @@ export default function RecipeList({
                     )}
                   </div>
                   {/* Instructions */}
-                  <div className="flex flex-col justify-start items-start pl-8">
+                  <div className="flex flex-col justify-start items-start md:pl-8">
                     {r.instructions && (
                       <>
                         <h3 className="font-semibold text-[var(--text-primary)] mb-1">Instructions</h3>
@@ -139,7 +144,7 @@ export default function RecipeList({
                     )}
                   </div>
                   {/* Categories, Tags, IBA */}
-                  <div className="flex flex-col justify-start items-start pl-8">
+                  <div className="flex flex-col justify-start items-start md:pl-8">
                     {r.categories && r.categories.length > 0 && (
                       <div className="mb-2">
                         <h4 className="font-semibold text-[var(--text-primary)]">Category</h4>

--- a/frontend/src/components/Suggestions.tsx
+++ b/frontend/src/components/Suggestions.tsx
@@ -11,7 +11,7 @@ export default function Suggestions({ limit = 4 }: SuggestionsProps) {
   const [suggestions, setSuggestions] = useState<RecipeItem[]>([]);
 
   useEffect(() => {
-    getSuggestions(limit)
+    getSuggestions({ limit })
       .then(setSuggestions)
       .catch(() => setSuggestions([]));
   }, [limit]);

--- a/frontend/src/pages/Recipes.tsx
+++ b/frontend/src/pages/Recipes.tsx
@@ -1,7 +1,6 @@
 // Recipes.tsx - Page for searching, saving, and viewing cocktail recipes
 import { useEffect, useState, useRef } from 'react';
 import { listRecipes, searchRecipes, createRecipe } from '../api';
-import { Link } from 'react-router-dom';
 import { Search } from 'lucide-react';
 import RecipeList, { type RecipeItem } from '../components/RecipeList';
 


### PR DESCRIPTION
## Summary
- make `RecipeList` flexbox layout responsive
- stack recipe counts and action buttons on mobile
- adjust details grid for small screens
- fix `getSuggestions` call
- remove unused import in `Recipes`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687beea72ec48330ac1ce798f5351065