### PR TITLE
Add NOT filter for suggestions

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -22,4 +22,4 @@ The YAML file can be extended to refine the classification.
 
 ``GET /macros`` returns the list of available macro names. The suggestions
 endpoints accept ``macros`` and ``macro_mode`` query parameters to filter
-recipes by those flavour tags.
+recipes by those flavour tags. ``macro_mode`` can be ``and``, ``or`` or ``not``.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -246,7 +246,7 @@ export async function getSuggestions(options: {
   limit?: number;
   max_missing?: number;
   macros?: string[];
-  macro_mode?: 'and' | 'or';
+  macro_mode?: 'and' | 'or' | 'not';
 } = {}) {
   const params = new URLSearchParams();
   if (options.limit !== undefined) params.append('limit', String(options.limit));
@@ -263,9 +263,9 @@ export async function getSuggestions(options: {
 
 export async function getSuggestionsByIngredients(options: {
   ingredients: number[];
-  mode?: 'and' | 'or';
+  mode?: 'and' | 'or' | 'not';
   macros?: string[];
-  macro_mode?: 'and' | 'or';
+  macro_mode?: 'and' | 'or' | 'not';
   max_missing?: number;
   limit?: number;
 }) {

--- a/frontend/src/pages/Suggestions.tsx
+++ b/frontend/src/pages/Suggestions.tsx
@@ -10,8 +10,8 @@ import RecipeList, { type RecipeItem } from '../components/RecipeList';
 export default function SuggestionsPage() {
   const [items, setItems] = useState<InventoryItem[]>([]);
   const [selected, setSelected] = useState<number[]>([]);
-  const [mode, setMode] = useState<'and' | 'or'>('and');
-  const [macroMode, setMacroMode] = useState<'and' | 'or'>('or');
+  const [mode, setMode] = useState<'and' | 'or' | 'not'>('and');
+  const [macroMode, setMacroMode] = useState<'and' | 'or' | 'not'>('or');
   const [maxMissing, setMaxMissing] = useState(3); // Default to 'egal'
   const [recipes, setRecipes] = useState<RecipeItem[]>([]);
   const [drag, setDrag] = useState<number | null>(null);
@@ -140,6 +140,13 @@ export default function SuggestionsPage() {
               >
                 OR
               </button>
+              <button
+                onClick={() => setMode('not')}
+                className={buttonClass(mode === 'not')}
+                title="None of the selected ingredients may be present"
+              >
+                NOT
+              </button>
             </div>
           </>
         )}
@@ -178,6 +185,13 @@ export default function SuggestionsPage() {
                 title="Any selected macro may be present"
               >
                 OR
+              </button>
+              <button
+                onClick={() => setMacroMode('not')}
+                className={buttonClass(macroMode === 'not')}
+                title="Selected macros must not be present"
+              >
+                NOT
               </button>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- extend backend suggestion filtering with `not` mode
- expose new filter in frontend API and UI
- document `macro_mode` values
- test NOT filtering with ingredients and macros

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3b5da4c08330ab823b51aead60af