### PR TITLE
Implement keep-awake utility

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,9 +10,12 @@ import Synonyms from "./pages/Synonyms";
 import SuggestionsPage from "./pages/Suggestions";
 import Navbar from "./components/Navbar";
 import { FilterProvider } from "./contexts/FilterContext";
+import { useKeepAwake } from "./hooks/useKeepAwake";
 import "./App.css";
 
 export default function App() {
+
+  useKeepAwake();
 
   return (
     <FilterProvider>

--- a/frontend/src/hooks/useKeepAwake.ts
+++ b/frontend/src/hooks/useKeepAwake.ts
@@ -1,0 +1,59 @@
+import { useEffect } from 'react';
+
+export function useKeepAwake() {
+  useEffect(() => {
+    let wakeLock: WakeLockSentinel | null = null;
+    let flip = false;
+
+    async function requestWakeLock() {
+      try {
+        if ('wakeLock' in navigator) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const nav: any = navigator;
+          wakeLock = await nav.wakeLock.request('screen');
+          wakeLock.addEventListener?.('release', () => {
+            wakeLock = null;
+          });
+        }
+      } catch (err) {
+        console.warn('WakeLock request failed:', err);
+      }
+    }
+
+    function nudge() {
+      try {
+        const y = flip ? 0 : 1;
+        window.scrollTo(0, y);
+        flip = !flip;
+      } catch {
+        /* noop */
+      }
+    }
+
+    function hiddenReloadFallback() {
+      if (document.hidden) {
+        setTimeout(() => {
+          if (document.hidden) location.reload();
+        }, 10 * 60 * 1000);
+      }
+    }
+
+    requestWakeLock();
+    const intervalId = setInterval(nudge, 60000);
+
+    const onVisibilityChange = () => {
+      if (!document.hidden) requestWakeLock();
+      hiddenReloadFallback();
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    const timeoutId = setTimeout(nudge, 15000);
+
+    return () => {
+      clearInterval(intervalId);
+      clearTimeout(timeoutId);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      wakeLock?.release().catch(() => {});
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- add `useKeepAwake` hook with wake lock and micro-scroll logic
- invoke keep-awake behavior in main `App` component

## Testing
- `pytest -q`
- `npm run lint` *(fails: 7 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6884d5a76c148330a476b908311ef858